### PR TITLE
Improved 'message' implementation

### DIFF
--- a/HotFix.Test/HotFix.Test.csproj
+++ b/HotFix.Test/HotFix.Test.csproj
@@ -67,6 +67,7 @@
     <Compile Include="core\field\checking_the_value_for_integer_equality.cs" />
     <Compile Include="core\field\checking_the_value_for_long_equality.cs" />
     <Compile Include="core\field\checking_the_value_for_string_equality.cs" />
+    <Compile Include="core\message\check_for_a_field.cs" />
     <Compile Include="utilities\parser\datetimes.cs" />
     <Compile Include="utilities\parser\floats.cs" />
     <Compile Include="utilities\parser\ints.cs" />

--- a/HotFix.Test/core/message/check_for_a_field.cs
+++ b/HotFix.Test/core/message/check_for_a_field.cs
@@ -1,0 +1,51 @@
+using System;
+using FluentAssertions;
+using HotFix.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HotFix.Test.core.message
+{
+    [TestClass]
+    public class check_for_a_field
+    {
+        public Message Message { get; set; }
+        public string Logon { get; set; }
+
+        [TestInitialize]
+        public void Setup()
+        {
+            Message = new Message();
+            Logon = "8=FIX.4.2|9=70|35=A|34=1|52=20170607-12:17:52.355|49=DAEV|56=TARGET|98=0|108=5|141=Y|10=231|".Replace("|", "\u0001");
+        }
+
+        [TestMethod]
+        public void returns_true_when_the_field_exists()
+        {
+            Message.Parse(Logon);
+
+            Message.Contains(8).Should().Be(true);
+            Message.Contains(9).Should().Be(true);
+            Message.Contains(35).Should().Be(true);
+            Message.Contains(34).Should().Be(true);
+            Message.Contains(52).Should().Be(true);
+            Message.Contains(49).Should().Be(true);
+            Message.Contains(56).Should().Be(true);
+            Message.Contains(98).Should().Be(true);
+            Message.Contains(108).Should().Be(true);
+            Message.Contains(141).Should().Be(true);
+            Message.Contains(10).Should().Be(true);
+        }
+
+        [TestMethod]
+        public void returns_false_when_the_field_does_not_exist()
+        {
+            Message.Contains(999).Should().Be(false);
+        }
+
+        [TestMethod]
+        public void returns_false_when_the_field_instance_does_not_exist()
+        {
+            Message.Contains(108, 2).Should().Be(false);
+        }
+    }
+}

--- a/HotFix.Test/core/message/parse_from_string.cs
+++ b/HotFix.Test/core/message/parse_from_string.cs
@@ -23,88 +23,107 @@ namespace HotFix.Test.core.message
         {
             Message.Parse(Logon);
 
+            Message.Valid.Should().Be(true);
             Message.Count.Should().Be(11);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(Exception))]
         public void fails_when_the_beginstring_field_is_missing()
         {
             Logon = Logon.Replace("8=FIX.4.2\u0001", "");
 
             Message.Parse(Logon);
+
+            Message.Valid.Should().Be(false);
+            Message.Count.Should().Be(0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(Exception))]
         public void fails_when_the_bodylength_field_is_missing()
         {
             Logon = Logon.Replace("9=70\u0001", "");
 
             Message.Parse(Logon);
+
+            Message.Valid.Should().Be(false);
+            Message.Count.Should().Be(0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(Exception))]
         public void fails_when_the_msgtype_field_is_missing()
         {
             Logon = Logon.Replace("35=A\u0001", "");
 
             Message.Parse(Logon);
+
+            Message.Valid.Should().Be(false);
+            Message.Count.Should().Be(0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(Exception))]
         public void fails_when_the_checksum_field_is_missing()
         {
             Logon = Logon.Replace("10=231\u0001", "");
 
             Message.Parse(Logon);
+
+            Message.Valid.Should().Be(false);
+            Message.Count.Should().Be(0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(Exception))]
         public void fails_when_a_tag_is_missing()
         {
             Logon = Logon.Replace("34=1\u0001", "=1\u0001");
 
             Message.Parse(Logon);
+
+            Message.Valid.Should().Be(false);
+            Message.Count.Should().Be(0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(Exception))]
         public void fails_when_the_bodylength_field_does_not_match_the_actual_length_of_the_message()
         {
             Logon = Logon.Replace("9=70\u0001", "9=81\u0001");
 
             Message.Parse(Logon);
+
+            Message.Valid.Should().Be(false);
+            Message.Count.Should().Be(0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(Exception))]
         public void fails_when_the_checksum_field_does_not_match_the_calculated_checksum_of_the_message()
         {
             Logon = Logon.Replace("10=231\u0001", "10=100\u0001");
 
             Message.Parse(Logon);
+
+            Message.Valid.Should().Be(false);
+            Message.Count.Should().Be(0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(Exception))]
         public void fails_when_a_tag_is_not_a_number()
         {
             Logon = Logon.Replace("34=1\u0001", "3X=1\u0001");
 
             Message.Parse(Logon);
+
+            Message.Valid.Should().Be(false);
+            Message.Count.Should().Be(0);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(Exception))]
         public void fails_when_a_value_is_missing()
         {
             Logon = Logon.Replace("34=1\u0001", "34=\u0001");
 
             Message.Parse(Logon);
+
+            Message.Valid.Should().Be(false);
+            Message.Count.Should().Be(0);
         }
     }
 }

--- a/HotFix/Core/Session.cs
+++ b/HotFix/Core/Session.cs
@@ -91,6 +91,8 @@ namespace HotFix.Core
 
         private void Process(Message message)
         {
+            if (!message.Valid) return;
+
             switch (message[35].AsString)
             {
                 case "0":


### PR DESCRIPTION
- Added a 'contains' function to message for checking whether a field exists
- Refactored error handling for invalid/garbled messages
    - Parsing no longer throws exceptions to external caller
    - Parsing failures are now denoted via the 'valid' field
- Session checks whether a message is valid before processing