### PR TITLE
Feature/encoding

### DIFF
--- a/HotFix.Benchmark/suites/parsing_messages.cs
+++ b/HotFix.Benchmark/suites/parsing_messages.cs
@@ -25,13 +25,13 @@ namespace HotFix.Benchmark.suites
             Message = new Message();
 
             _heartbeat =
-                Encoding.ASCII.GetBytes(
+                System.Text.Encoding.ASCII.GetBytes(
                     ("8=FIX.4.2|9=74|35=8|34=000008059|52=20170531-08:18:01.768|49=SENDER....|56=RECEIVER....." +
                     "|10=048|")
                 .Replace("|", "\u0001"));
 
             _executionReport =
-                Encoding.ASCII.GetBytes(
+                System.Text.Encoding.ASCII.GetBytes(
                     ("8=FIX.4.2|9=354|35=8|34=000008059|52=20170531-08:18:01.768|49=SENDER....|56=RECEIVER.....|20=0|39=2|150=2" +
                     "|17=U201:053117:00000079:B|40=2|55=EUR/CAD|54=1|38=000900000.00|151=000000000.00|14=000900000.00|32=000100000.00|31=00001.503850" +
                     "|6=00001.503940|64=20170602|60=20170531-08:18:01.767|75=20170531|9200=S|9300=0647|9500=00000.000000|37=0804188884|15=EUR|44=00001.504200" +
@@ -39,7 +39,7 @@ namespace HotFix.Benchmark.suites
                 .Replace("|", "\u0001"));
 
             _marketDataIncrementalRefresh = 
-                Encoding.ASCII.GetBytes(
+                System.Text.Encoding.ASCII.GetBytes(
                     ("8=FIX.4.2|9=968|35=X|34=53677|52=20170525-00:55:16.153|49=SENDER..|56=RECEIVER..........|262=c6424b19-af74-4c17-8266-9c52ca583ad2" +
                     "|268=8" +
                     "|279=2|55=GBP/JPY|269=0|278=1211918436|270=144.808000|271=1000000.000000|110=0.000000|15=GBP|282=290" +

--- a/HotFix.Benchmark/suites/reading/reading_datetimes.cs
+++ b/HotFix.Benchmark/suites/reading/reading_datetimes.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using System.Text;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Columns;
 using BenchmarkDotNet.Attributes.Jobs;
 using BenchmarkDotNet.Engines;
-using HotFix.Utilities;
+using HotFix.Encoding;
 
 namespace HotFix.Benchmark.suites.reading
 {
@@ -18,14 +17,14 @@ namespace HotFix.Benchmark.suites.reading
         [Setup]
         public void Setup()
         {
-            _raw = Encoding.ASCII.GetBytes("20170327-15:45:13.596");
+            _raw = System.Text.Encoding.ASCII.GetBytes("20170327-15:45:13.596");
         }
 
         // NOTE: We return long here because returning datetime seems to cause allocation
         //       which is possibly an issue in the benchmarking library (investigate)
 
         [Benchmark(Baseline = true)]
-        public long standard() => DateTime.ParseExact(Encoding.ASCII.GetString(_raw), "yyyyMMdd-HH:mm:ss.fff", null).Ticks;
+        public long standard() => DateTime.ParseExact(System.Text.Encoding.ASCII.GetString(_raw), "yyyyMMdd-HH:mm:ss.fff", null).Ticks;
 
         [Benchmark]
         public long hotfix() => _raw.GetDateTime().Ticks;

--- a/HotFix.Benchmark/suites/reading/reading_datetimes.cs
+++ b/HotFix.Benchmark/suites/reading/reading_datetimes.cs
@@ -27,6 +27,6 @@ namespace HotFix.Benchmark.suites.reading
         public long standard() => DateTime.ParseExact(System.Text.Encoding.ASCII.GetString(_raw), "yyyyMMdd-HH:mm:ss.fff", null).Ticks;
 
         [Benchmark]
-        public long hotfix() => _raw.GetDateTime().Ticks;
+        public long hotfix() => _raw.ReadDateTime().Ticks;
     }
 }

--- a/HotFix.Benchmark/suites/reading/reading_floats.cs
+++ b/HotFix.Benchmark/suites/reading/reading_floats.cs
@@ -25,6 +25,6 @@ namespace HotFix.Benchmark.suites.reading
         public double standard() => double.Parse(System.Text.Encoding.ASCII.GetString(_raw));
 
         [Benchmark]
-        public double hotfix() => _raw.GetFloat();
+        public double hotfix() => _raw.ReadFloat();
     }
 }

--- a/HotFix.Benchmark/suites/reading/reading_floats.cs
+++ b/HotFix.Benchmark/suites/reading/reading_floats.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Columns;
 using BenchmarkDotNet.Attributes.Jobs;
 using BenchmarkDotNet.Engines;
-using HotFix.Utilities;
+using HotFix.Encoding;
 
 namespace HotFix.Benchmark.suites.reading
 {
@@ -18,11 +18,11 @@ namespace HotFix.Benchmark.suites.reading
         [Setup]
         public void Setup()
         {
-            _raw = Encoding.ASCII.GetBytes("12345.6789");
+            _raw = System.Text.Encoding.ASCII.GetBytes("12345.6789");
         }
 
         [Benchmark(Baseline = true)]
-        public double standard() => double.Parse(Encoding.ASCII.GetString(_raw));
+        public double standard() => double.Parse(System.Text.Encoding.ASCII.GetString(_raw));
 
         [Benchmark]
         public double hotfix() => _raw.GetFloat();

--- a/HotFix.Benchmark/suites/reading/reading_ints.cs
+++ b/HotFix.Benchmark/suites/reading/reading_ints.cs
@@ -25,6 +25,6 @@ namespace HotFix.Benchmark.suites.reading
         public int standard() => int.Parse(System.Text.Encoding.ASCII.GetString(_raw));
 
         [Benchmark]
-        public int hotfix() => _raw.GetInt();
+        public int hotfix() => _raw.ReadInt();
     }
 }

--- a/HotFix.Benchmark/suites/reading/reading_ints.cs
+++ b/HotFix.Benchmark/suites/reading/reading_ints.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Columns;
 using BenchmarkDotNet.Attributes.Jobs;
 using BenchmarkDotNet.Engines;
-using HotFix.Utilities;
+using HotFix.Encoding;
 
 namespace HotFix.Benchmark.suites.reading
 {
@@ -18,11 +18,11 @@ namespace HotFix.Benchmark.suites.reading
         [Setup]
         public void Setup()
         {
-            _raw = Encoding.ASCII.GetBytes("12345");
+            _raw = System.Text.Encoding.ASCII.GetBytes("12345");
         }
 
         [Benchmark(Baseline = true)]
-        public int standard() => int.Parse(Encoding.ASCII.GetString(_raw));
+        public int standard() => int.Parse(System.Text.Encoding.ASCII.GetString(_raw));
 
         [Benchmark]
         public int hotfix() => _raw.GetInt();

--- a/HotFix.Benchmark/suites/reading/reading_longs.cs
+++ b/HotFix.Benchmark/suites/reading/reading_longs.cs
@@ -25,6 +25,6 @@ namespace HotFix.Benchmark.suites.reading
         public long standard() => long.Parse(System.Text.Encoding.ASCII.GetString(_raw));
 
         [Benchmark]
-        public long hotfix() => _raw.GetLong();
+        public long hotfix() => _raw.ReadLong();
     }
 }

--- a/HotFix.Benchmark/suites/reading/reading_longs.cs
+++ b/HotFix.Benchmark/suites/reading/reading_longs.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Columns;
 using BenchmarkDotNet.Attributes.Jobs;
 using BenchmarkDotNet.Engines;
-using HotFix.Utilities;
+using HotFix.Encoding;
 
 namespace HotFix.Benchmark.suites.reading
 {
@@ -18,11 +18,11 @@ namespace HotFix.Benchmark.suites.reading
         [Setup]
         public void Setup()
         {
-            _raw = Encoding.ASCII.GetBytes("123456789");
+            _raw = System.Text.Encoding.ASCII.GetBytes("123456789");
         }
 
         [Benchmark(Baseline = true)]
-        public long standard() => long.Parse(Encoding.ASCII.GetString(_raw));
+        public long standard() => long.Parse(System.Text.Encoding.ASCII.GetString(_raw));
 
         [Benchmark]
         public long hotfix() => _raw.GetLong();

--- a/HotFix.Benchmark/suites/reading/reading_strings.cs
+++ b/HotFix.Benchmark/suites/reading/reading_strings.cs
@@ -25,6 +25,6 @@ namespace HotFix.Benchmark.suites.reading
         public string standard() => System.Text.Encoding.ASCII.GetString(_raw, 3, 3);
 
         [Benchmark]
-        public string hotfix() => _raw.GetString(3, 3);
+        public string hotfix() => _raw.ReadString(3, 3);
     }
 }

--- a/HotFix.Benchmark/suites/reading/reading_strings.cs
+++ b/HotFix.Benchmark/suites/reading/reading_strings.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Columns;
 using BenchmarkDotNet.Attributes.Jobs;
 using BenchmarkDotNet.Engines;
-using HotFix.Utilities;
+using HotFix.Encoding;
 
 namespace HotFix.Benchmark.suites.reading
 {
@@ -18,11 +18,11 @@ namespace HotFix.Benchmark.suites.reading
         [Setup]
         public void Setup()
         {
-            _raw = Encoding.ASCII.GetBytes("123456789");
+            _raw = System.Text.Encoding.ASCII.GetBytes("123456789");
         }
 
         [Benchmark(Baseline = true)]
-        public string standard() => Encoding.ASCII.GetString(_raw, 3, 3);
+        public string standard() => System.Text.Encoding.ASCII.GetString(_raw, 3, 3);
 
         [Benchmark]
         public string hotfix() => _raw.GetString(3, 3);

--- a/HotFix.Benchmark/suites/writing/writing_datetimes.cs
+++ b/HotFix.Benchmark/suites/writing/writing_datetimes.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Columns;
 using BenchmarkDotNet.Attributes.Jobs;
 using BenchmarkDotNet.Engines;
-using HotFix.Utilities;
+using HotFix.Encoding;
 
 namespace HotFix.Benchmark.suites.writing
 {
@@ -27,7 +27,7 @@ namespace HotFix.Benchmark.suites.writing
         public int standard()
         {
             var s = _dateTime.ToString("yyyyMMdd-HH:mm:ss.fff");
-            return Encoding.ASCII.GetBytes(s, 0, s.Length, _buffer, 0);
+            return System.Text.Encoding.ASCII.GetBytes(s, 0, s.Length, _buffer, 0);
         }
 
         [Benchmark]

--- a/HotFix.Benchmark/suites/writing/writing_floats.cs
+++ b/HotFix.Benchmark/suites/writing/writing_floats.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Columns;
 using BenchmarkDotNet.Attributes.Jobs;
 using BenchmarkDotNet.Engines;
-using HotFix.Utilities;
+using HotFix.Encoding;
 
 namespace HotFix.Benchmark.suites.writing
 {
@@ -27,7 +27,7 @@ namespace HotFix.Benchmark.suites.writing
         public int standard()
         {
             var s = _number.ToString();
-            return Encoding.ASCII.GetBytes(s, 0, s.Length, _buffer, 0);
+            return System.Text.Encoding.ASCII.GetBytes(s, 0, s.Length, _buffer, 0);
         }
 
         [Benchmark]

--- a/HotFix.Benchmark/suites/writing/writing_ints.cs
+++ b/HotFix.Benchmark/suites/writing/writing_ints.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Columns;
 using BenchmarkDotNet.Attributes.Jobs;
 using BenchmarkDotNet.Engines;
-using HotFix.Utilities;
+using HotFix.Encoding;
 
 namespace HotFix.Benchmark.suites.writing
 {
@@ -27,7 +27,7 @@ namespace HotFix.Benchmark.suites.writing
         public int standard()
         {
             var s = _number.ToString();
-            return Encoding.ASCII.GetBytes(s, 0, s.Length, _buffer, 0);
+            return System.Text.Encoding.ASCII.GetBytes(s, 0, s.Length, _buffer, 0);
         }
 
         [Benchmark]

--- a/HotFix.Benchmark/suites/writing/writing_longs.cs
+++ b/HotFix.Benchmark/suites/writing/writing_longs.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Columns;
 using BenchmarkDotNet.Attributes.Jobs;
 using BenchmarkDotNet.Engines;
-using HotFix.Utilities;
+using HotFix.Encoding;
 
 namespace HotFix.Benchmark.suites.writing
 {
@@ -27,7 +27,7 @@ namespace HotFix.Benchmark.suites.writing
         public int standard()
         {
             var s = _number.ToString();
-            return Encoding.ASCII.GetBytes(s, 0, s.Length, _buffer, 0);
+            return System.Text.Encoding.ASCII.GetBytes(s, 0, s.Length, _buffer, 0);
         }
 
         [Benchmark]

--- a/HotFix.Benchmark/suites/writing/writing_strings.cs
+++ b/HotFix.Benchmark/suites/writing/writing_strings.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Columns;
 using BenchmarkDotNet.Attributes.Jobs;
 using BenchmarkDotNet.Engines;
-using HotFix.Utilities;
+using HotFix.Encoding;
 
 namespace HotFix.Benchmark.suites.writing
 {
@@ -26,7 +26,7 @@ namespace HotFix.Benchmark.suites.writing
         [Benchmark(Baseline = true)]
         public int standard()
         {
-            return Encoding.ASCII.GetBytes(_string, 0, _string.Length, _buffer, 0);
+            return System.Text.Encoding.ASCII.GetBytes(_string, 0, _string.Length, _buffer, 0);
         }
 
         [Benchmark]

--- a/HotFix.Test/core/field/checking_the_value_for_datetime_equality.cs
+++ b/HotFix.Test/core/field/checking_the_value_for_datetime_equality.cs
@@ -12,7 +12,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_a_valid_datetime()
         {
-            var field = new Field(Encoding.ASCII.GetBytes("34=XXXXXX-YY:YY:YY.ZZZ\u0001"), 0, new Segment(3, 21), 25, 0);
+            var field = new Field(System.Text.Encoding.ASCII.GetBytes("34=XXXXXX-YY:YY:YY.ZZZ\u0001"), 0, new Segment(3, 21), 25, 0);
 
             field.Is(DateTime.Parse("27/03/2017 09:34:21.456")).Should().Be(false);
         }
@@ -20,7 +20,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_equal_to_the_input()
         {
-            var field = new Field(Encoding.ASCII.GetBytes("34=20170423-12:32:23.123\u0001"), 0, new Segment(3, 21), 25, 0);
+            var field = new Field(System.Text.Encoding.ASCII.GetBytes("34=20170423-12:32:23.123\u0001"), 0, new Segment(3, 21), 25, 0);
 
             field.Is(DateTime.Parse("27/03/2017 09:34:21.456")).Should().Be(false);
         }
@@ -28,7 +28,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_true_when_the_value_is_equal_to_the_input()
         {
-            var field = new Field(Encoding.ASCII.GetBytes("34=20170327-09:34:21.456\u0001"), 0, new Segment(3, 21), 25, 0);
+            var field = new Field(System.Text.Encoding.ASCII.GetBytes("34=20170327-09:34:21.456\u0001"), 0, new Segment(3, 21), 25, 0);
 
             field.Is(DateTime.Parse("27/03/2017 09:34:21.456")).Should().Be(true);
         }

--- a/HotFix.Test/core/field/checking_the_value_for_double_equality.cs
+++ b/HotFix.Test/core/field/checking_the_value_for_double_equality.cs
@@ -12,7 +12,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_a_valid_double()
         {
-            var field = new Field(Encoding.ASCII.GetBytes("34=XXXXXX\u0001"), 0, new Segment(3, 6), 10, 0);
+            var field = new Field(System.Text.Encoding.ASCII.GetBytes("34=XXXXXX\u0001"), 0, new Segment(3, 6), 10, 0);
 
             field.Is(123.45d).Should().Be(false);
         }
@@ -20,7 +20,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_equal_to_the_input()
         {
-            var field = new Field(Encoding.ASCII.GetBytes("34=543.21\u0001"), 0, new Segment(3, 6), 10, 0);
+            var field = new Field(System.Text.Encoding.ASCII.GetBytes("34=543.21\u0001"), 0, new Segment(3, 6), 10, 0);
 
             field.Is(123.45d).Should().Be(false);
         }
@@ -28,7 +28,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_true_when_the_value_is_equal_to_the_input()
         {
-            var field = new Field(Encoding.ASCII.GetBytes("34=123.45\u0001"), 0, new Segment(3, 6), 10, 0);
+            var field = new Field(System.Text.Encoding.ASCII.GetBytes("34=123.45\u0001"), 0, new Segment(3, 6), 10, 0);
 
             field.Is(123.45d).Should().Be(true);
         }

--- a/HotFix.Test/core/field/checking_the_value_for_integer_equality.cs
+++ b/HotFix.Test/core/field/checking_the_value_for_integer_equality.cs
@@ -12,7 +12,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_a_valid_integer()
         {
-            var field = new Field(Encoding.ASCII.GetBytes("34=XXXXX\u0001"), 0, new Segment(3, 5), 9, 0);
+            var field = new Field(System.Text.Encoding.ASCII.GetBytes("34=XXXXX\u0001"), 0, new Segment(3, 5), 9, 0);
 
             field.Is(12345).Should().Be(false);
         }
@@ -20,7 +20,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_equal_to_the_input()
         {
-            var field = new Field(Encoding.ASCII.GetBytes("34=54321\u0001"), 0, new Segment(3, 5), 9, 0);
+            var field = new Field(System.Text.Encoding.ASCII.GetBytes("34=54321\u0001"), 0, new Segment(3, 5), 9, 0);
 
             field.Is(12345).Should().Be(false);
         }
@@ -28,7 +28,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_true_when_the_value_is_equal_to_the_input()
         {
-            var field = new Field(Encoding.ASCII.GetBytes("34=12345\u0001"), 0, new Segment(3, 5), 9, 0);
+            var field = new Field(System.Text.Encoding.ASCII.GetBytes("34=12345\u0001"), 0, new Segment(3, 5), 9, 0);
 
             field.Is(12345).Should().Be(true);
         }

--- a/HotFix.Test/core/field/checking_the_value_for_long_equality.cs
+++ b/HotFix.Test/core/field/checking_the_value_for_long_equality.cs
@@ -12,7 +12,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_a_valid_long()
         {
-            var field = new Field(Encoding.ASCII.GetBytes("34=XXXXX\u0001"), 0, new Segment(3, 5), 9, 0);
+            var field = new Field(System.Text.Encoding.ASCII.GetBytes("34=XXXXX\u0001"), 0, new Segment(3, 5), 9, 0);
 
             field.Is(12345L).Should().Be(false);
         }
@@ -20,7 +20,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_equal_to_the_input()
         {
-            var field = new Field(Encoding.ASCII.GetBytes("34=54321\u0001"), 0, new Segment(3, 5), 9, 0);
+            var field = new Field(System.Text.Encoding.ASCII.GetBytes("34=54321\u0001"), 0, new Segment(3, 5), 9, 0);
 
             field.Is(12345L).Should().Be(false);
         }
@@ -28,7 +28,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_true_when_the_value_is_equal_to_the_input()
         {
-            var field = new Field(Encoding.ASCII.GetBytes("34=12345\u0001"), 0, new Segment(3, 5), 9, 0);
+            var field = new Field(System.Text.Encoding.ASCII.GetBytes("34=12345\u0001"), 0, new Segment(3, 5), 9, 0);
 
             field.Is(12345L).Should().Be(true);
         }

--- a/HotFix.Test/core/field/checking_the_value_for_string_equality.cs
+++ b/HotFix.Test/core/field/checking_the_value_for_string_equality.cs
@@ -12,7 +12,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_equal_to_the_input()
         {
-            var field = new Field(Encoding.ASCII.GetBytes("34=XXXXXX\u0001"), 0, new Segment(3, 6), 10, 0);
+            var field = new Field(System.Text.Encoding.ASCII.GetBytes("34=XXXXXX\u0001"), 0, new Segment(3, 6), 10, 0);
 
             field.Is("ABCDEF").Should().Be(false);
         }
@@ -20,7 +20,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_true_when_the_value_is_equal_to_the_input()
         {
-            var field = new Field(Encoding.ASCII.GetBytes("34=ABCDEF\u0001"), 0, new Segment(3, 6), 10, 0);
+            var field = new Field(System.Text.Encoding.ASCII.GetBytes("34=ABCDEF\u0001"), 0, new Segment(3, 6), 10, 0);
 
             field.Is("ABCDEF").Should().Be(true);
         }

--- a/HotFix.Test/core/message/check_for_a_field.cs
+++ b/HotFix.Test/core/message/check_for_a_field.cs
@@ -22,7 +22,7 @@ namespace HotFix.Test.core.message
         [TestMethod]
         public void returns_true_when_the_field_exists()
         {
-            Message.Parse(Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
 
             Message.Contains(8).Should().Be(true);
             Message.Contains(9).Should().Be(true);

--- a/HotFix.Test/core/message/converting_to_string.cs
+++ b/HotFix.Test/core/message/converting_to_string.cs
@@ -22,7 +22,7 @@ namespace HotFix.Test.core.message
         [TestMethod]
         public void returns_the_original_string()
         {
-            Message.Parse(Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
 
             Message.ToString().Should().Be(Logon);
         }

--- a/HotFix.Test/core/message/parse_from_string.cs
+++ b/HotFix.Test/core/message/parse_from_string.cs
@@ -22,7 +22,7 @@ namespace HotFix.Test.core.message
         [TestMethod]
         public void succeeds_when_the_message_is_valid()
         {
-            Message.Parse(Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
 
             Message.Valid.Should().Be(true);
             Message.Count.Should().Be(11);
@@ -33,7 +33,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("8=FIX.4.2\u0001", "");
 
-            Message.Parse(Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -44,7 +44,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("9=70\u0001", "");
 
-            Message.Parse(Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -55,7 +55,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("35=A\u0001", "");
 
-            Message.Parse(Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -66,7 +66,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("10=231\u0001", "");
 
-            Message.Parse(Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -77,7 +77,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("34=1\u0001", "=1\u0001");
 
-            Message.Parse(Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -88,7 +88,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("9=70\u0001", "9=81\u0001");
 
-            Message.Parse(Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -99,7 +99,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("10=231\u0001", "10=100\u0001");
 
-            Message.Parse(Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -110,7 +110,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("34=1\u0001", "3X=1\u0001");
 
-            Message.Parse(Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -121,7 +121,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("34=1\u0001", "34=\u0001");
 
-            Message.Parse(Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);

--- a/HotFix.Test/core/message/retrieve_a_field.cs
+++ b/HotFix.Test/core/message/retrieve_a_field.cs
@@ -22,7 +22,7 @@ namespace HotFix.Test.core.message
         [TestMethod]
         public void succeeds_when_the_field_exists()
         {
-            var bytes = Encoding.ASCII.GetBytes(Logon);
+            var bytes = System.Text.Encoding.ASCII.GetBytes(Logon);
             Message.Parse(bytes, 0, bytes.Length);
 
             Message[  8].AsString.Should().Be("FIX.4.2");

--- a/HotFix.Test/utilities/reading/datetimes.cs
+++ b/HotFix.Test/utilities/reading/datetimes.cs
@@ -12,7 +12,7 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void timestamp()
         {
-            var result = System.Text.Encoding.ASCII.GetBytes("20170327-15:45:13").GetDateTime();
+            var result = System.Text.Encoding.ASCII.GetBytes("20170327-15:45:13").ReadDateTime();
 
             result.Should().Be(DateTime.Parse("27/03/2017 15:45:13"));
         }
@@ -20,7 +20,7 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void timestamp_with_milliseconds()
         {
-            var result = System.Text.Encoding.ASCII.GetBytes("20170327-15:45:13.596").GetDateTime();
+            var result = System.Text.Encoding.ASCII.GetBytes("20170327-15:45:13.596").ReadDateTime();
 
             result.Should().Be(DateTime.Parse("27/03/2017 15:45:13.596"));
         }

--- a/HotFix.Test/utilities/reading/datetimes.cs
+++ b/HotFix.Test/utilities/reading/datetimes.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Text;
 using FluentAssertions;
-using HotFix.Utilities;
+using HotFix.Encoding;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HotFix.Test.utilities.reading
@@ -12,7 +12,7 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void timestamp()
         {
-            var result = Encoding.ASCII.GetBytes("20170327-15:45:13").GetDateTime();
+            var result = System.Text.Encoding.ASCII.GetBytes("20170327-15:45:13").GetDateTime();
 
             result.Should().Be(DateTime.Parse("27/03/2017 15:45:13"));
         }
@@ -20,7 +20,7 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void timestamp_with_milliseconds()
         {
-            var result = Encoding.ASCII.GetBytes("20170327-15:45:13.596").GetDateTime();
+            var result = System.Text.Encoding.ASCII.GetBytes("20170327-15:45:13.596").GetDateTime();
 
             result.Should().Be(DateTime.Parse("27/03/2017 15:45:13.596"));
         }

--- a/HotFix.Test/utilities/reading/floats.cs
+++ b/HotFix.Test/utilities/reading/floats.cs
@@ -12,61 +12,61 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void zero()
         {
-            System.Text.Encoding.ASCII.GetBytes("0").GetFloat().Should().Be(0d);
+            System.Text.Encoding.ASCII.GetBytes("0").ReadFloat().Should().Be(0d);
         }
 
         [TestMethod]
         public void zero_with_decimals()
         {
-            System.Text.Encoding.ASCII.GetBytes("0.0").GetFloat().Should().Be(0.0d);
+            System.Text.Encoding.ASCII.GetBytes("0.0").ReadFloat().Should().Be(0.0d);
         }
 
         [TestMethod]
         public void positive()
         {
-            System.Text.Encoding.ASCII.GetBytes("123").GetFloat().Should().Be(123d);
+            System.Text.Encoding.ASCII.GetBytes("123").ReadFloat().Should().Be(123d);
         }
 
         [TestMethod]
         public void positive_with_decimals()
         {
-            System.Text.Encoding.ASCII.GetBytes("123.456789").GetFloat().Should().Be(123.456789d);
+            System.Text.Encoding.ASCII.GetBytes("123.456789").ReadFloat().Should().Be(123.456789d);
         }
 
         [TestMethod]
         public void positive_with_decimals_and_leading_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("000123.456789").GetFloat().Should().Be(123.456789d);
+            System.Text.Encoding.ASCII.GetBytes("000123.456789").ReadFloat().Should().Be(123.456789d);
         }
 
         [TestMethod]
         public void positive_with_decimals_and_trailing_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("123.456789000").GetFloat().Should().Be(123.456789d);
+            System.Text.Encoding.ASCII.GetBytes("123.456789000").ReadFloat().Should().Be(123.456789d);
         }
 
         [TestMethod]
         public void negative()
         {
-            System.Text.Encoding.ASCII.GetBytes("-123").GetFloat().Should().Be(-123d);
+            System.Text.Encoding.ASCII.GetBytes("-123").ReadFloat().Should().Be(-123d);
         }
 
         [TestMethod]
         public void negative_with_decimals()
         {
-            System.Text.Encoding.ASCII.GetBytes("-123.456789").GetFloat().Should().Be(-123.456789d);
+            System.Text.Encoding.ASCII.GetBytes("-123.456789").ReadFloat().Should().Be(-123.456789d);
         }
 
         [TestMethod]
         public void negative_with_decimals_and_leading_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("-000123.456789").GetFloat().Should().Be(-123.456789d);
+            System.Text.Encoding.ASCII.GetBytes("-000123.456789").ReadFloat().Should().Be(-123.456789d);
         }
 
         [TestMethod]
         public void negative_with_decimals_and_trailing_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("-123.456789000").GetFloat().Should().Be(-123.456789d);
+            System.Text.Encoding.ASCII.GetBytes("-123.456789000").ReadFloat().Should().Be(-123.456789d);
         }
     }
 }

--- a/HotFix.Test/utilities/reading/floats.cs
+++ b/HotFix.Test/utilities/reading/floats.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Text;
 using FluentAssertions;
-using HotFix.Utilities;
+using HotFix.Encoding;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HotFix.Test.utilities.reading
@@ -12,61 +12,61 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void zero()
         {
-            Encoding.ASCII.GetBytes("0").GetFloat().Should().Be(0d);
+            System.Text.Encoding.ASCII.GetBytes("0").GetFloat().Should().Be(0d);
         }
 
         [TestMethod]
         public void zero_with_decimals()
         {
-            Encoding.ASCII.GetBytes("0.0").GetFloat().Should().Be(0.0d);
+            System.Text.Encoding.ASCII.GetBytes("0.0").GetFloat().Should().Be(0.0d);
         }
 
         [TestMethod]
         public void positive()
         {
-            Encoding.ASCII.GetBytes("123").GetFloat().Should().Be(123d);
+            System.Text.Encoding.ASCII.GetBytes("123").GetFloat().Should().Be(123d);
         }
 
         [TestMethod]
         public void positive_with_decimals()
         {
-            Encoding.ASCII.GetBytes("123.456789").GetFloat().Should().Be(123.456789d);
+            System.Text.Encoding.ASCII.GetBytes("123.456789").GetFloat().Should().Be(123.456789d);
         }
 
         [TestMethod]
         public void positive_with_decimals_and_leading_zeros()
         {
-            Encoding.ASCII.GetBytes("000123.456789").GetFloat().Should().Be(123.456789d);
+            System.Text.Encoding.ASCII.GetBytes("000123.456789").GetFloat().Should().Be(123.456789d);
         }
 
         [TestMethod]
         public void positive_with_decimals_and_trailing_zeros()
         {
-            Encoding.ASCII.GetBytes("123.456789000").GetFloat().Should().Be(123.456789d);
+            System.Text.Encoding.ASCII.GetBytes("123.456789000").GetFloat().Should().Be(123.456789d);
         }
 
         [TestMethod]
         public void negative()
         {
-            Encoding.ASCII.GetBytes("-123").GetFloat().Should().Be(-123d);
+            System.Text.Encoding.ASCII.GetBytes("-123").GetFloat().Should().Be(-123d);
         }
 
         [TestMethod]
         public void negative_with_decimals()
         {
-            Encoding.ASCII.GetBytes("-123.456789").GetFloat().Should().Be(-123.456789d);
+            System.Text.Encoding.ASCII.GetBytes("-123.456789").GetFloat().Should().Be(-123.456789d);
         }
 
         [TestMethod]
         public void negative_with_decimals_and_leading_zeros()
         {
-            Encoding.ASCII.GetBytes("-000123.456789").GetFloat().Should().Be(-123.456789d);
+            System.Text.Encoding.ASCII.GetBytes("-000123.456789").GetFloat().Should().Be(-123.456789d);
         }
 
         [TestMethod]
         public void negative_with_decimals_and_trailing_zeros()
         {
-            Encoding.ASCII.GetBytes("-123.456789000").GetFloat().Should().Be(-123.456789d);
+            System.Text.Encoding.ASCII.GetBytes("-123.456789000").GetFloat().Should().Be(-123.456789d);
         }
     }
 }

--- a/HotFix.Test/utilities/reading/ints.cs
+++ b/HotFix.Test/utilities/reading/ints.cs
@@ -12,31 +12,31 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void zero()
         {
-            System.Text.Encoding.ASCII.GetBytes("0").GetInt().Should().Be(0);
+            System.Text.Encoding.ASCII.GetBytes("0").ReadInt().Should().Be(0);
         }
 
         [TestMethod]
         public void positive()
         {
-            System.Text.Encoding.ASCII.GetBytes("123").GetInt().Should().Be(123);
+            System.Text.Encoding.ASCII.GetBytes("123").ReadInt().Should().Be(123);
         }
 
         [TestMethod]
         public void positive_with_leading_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("000123").GetInt().Should().Be(123);
+            System.Text.Encoding.ASCII.GetBytes("000123").ReadInt().Should().Be(123);
         }
 
         [TestMethod]
         public void negative()
         {
-            System.Text.Encoding.ASCII.GetBytes("-123").GetInt().Should().Be(-123);
+            System.Text.Encoding.ASCII.GetBytes("-123").ReadInt().Should().Be(-123);
         }
 
         [TestMethod]
         public void negative_with_leading_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("-000123").GetInt().Should().Be(-123);
+            System.Text.Encoding.ASCII.GetBytes("-000123").ReadInt().Should().Be(-123);
         }
     }
 }

--- a/HotFix.Test/utilities/reading/ints.cs
+++ b/HotFix.Test/utilities/reading/ints.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Text;
 using FluentAssertions;
-using HotFix.Utilities;
+using HotFix.Encoding;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HotFix.Test.utilities.reading
@@ -12,31 +12,31 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void zero()
         {
-            Encoding.ASCII.GetBytes("0").GetInt().Should().Be(0);
+            System.Text.Encoding.ASCII.GetBytes("0").GetInt().Should().Be(0);
         }
 
         [TestMethod]
         public void positive()
         {
-            Encoding.ASCII.GetBytes("123").GetInt().Should().Be(123);
+            System.Text.Encoding.ASCII.GetBytes("123").GetInt().Should().Be(123);
         }
 
         [TestMethod]
         public void positive_with_leading_zeros()
         {
-            Encoding.ASCII.GetBytes("000123").GetInt().Should().Be(123);
+            System.Text.Encoding.ASCII.GetBytes("000123").GetInt().Should().Be(123);
         }
 
         [TestMethod]
         public void negative()
         {
-            Encoding.ASCII.GetBytes("-123").GetInt().Should().Be(-123);
+            System.Text.Encoding.ASCII.GetBytes("-123").GetInt().Should().Be(-123);
         }
 
         [TestMethod]
         public void negative_with_leading_zeros()
         {
-            Encoding.ASCII.GetBytes("-000123").GetInt().Should().Be(-123);
+            System.Text.Encoding.ASCII.GetBytes("-000123").GetInt().Should().Be(-123);
         }
     }
 }

--- a/HotFix.Test/utilities/reading/longs.cs
+++ b/HotFix.Test/utilities/reading/longs.cs
@@ -12,31 +12,31 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void zero()
         {
-            System.Text.Encoding.ASCII.GetBytes("0").GetLong().Should().Be(0);
+            System.Text.Encoding.ASCII.GetBytes("0").ReadLong().Should().Be(0);
         }
 
         [TestMethod]
         public void positive()
         {
-            System.Text.Encoding.ASCII.GetBytes("1234567890987654321").GetLong().Should().Be(1234567890987654321L);
+            System.Text.Encoding.ASCII.GetBytes("1234567890987654321").ReadLong().Should().Be(1234567890987654321L);
         }
 
         [TestMethod]
         public void positive_with_leading_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("0001234567890987654321").GetLong().Should().Be(1234567890987654321L);
+            System.Text.Encoding.ASCII.GetBytes("0001234567890987654321").ReadLong().Should().Be(1234567890987654321L);
         }
 
         [TestMethod]
         public void negative()
         {
-            System.Text.Encoding.ASCII.GetBytes("-1234567890987654321").GetLong().Should().Be(-1234567890987654321L);
+            System.Text.Encoding.ASCII.GetBytes("-1234567890987654321").ReadLong().Should().Be(-1234567890987654321L);
         }
 
         [TestMethod]
         public void negative_with_leading_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("-0001234567890987654321").GetLong().Should().Be(-1234567890987654321L);
+            System.Text.Encoding.ASCII.GetBytes("-0001234567890987654321").ReadLong().Should().Be(-1234567890987654321L);
         }
     }
 }

--- a/HotFix.Test/utilities/reading/longs.cs
+++ b/HotFix.Test/utilities/reading/longs.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Text;
 using FluentAssertions;
-using HotFix.Utilities;
+using HotFix.Encoding;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HotFix.Test.utilities.reading
@@ -12,31 +12,31 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void zero()
         {
-            Encoding.ASCII.GetBytes("0").GetLong().Should().Be(0);
+            System.Text.Encoding.ASCII.GetBytes("0").GetLong().Should().Be(0);
         }
 
         [TestMethod]
         public void positive()
         {
-            Encoding.ASCII.GetBytes("1234567890987654321").GetLong().Should().Be(1234567890987654321L);
+            System.Text.Encoding.ASCII.GetBytes("1234567890987654321").GetLong().Should().Be(1234567890987654321L);
         }
 
         [TestMethod]
         public void positive_with_leading_zeros()
         {
-            Encoding.ASCII.GetBytes("0001234567890987654321").GetLong().Should().Be(1234567890987654321L);
+            System.Text.Encoding.ASCII.GetBytes("0001234567890987654321").GetLong().Should().Be(1234567890987654321L);
         }
 
         [TestMethod]
         public void negative()
         {
-            Encoding.ASCII.GetBytes("-1234567890987654321").GetLong().Should().Be(-1234567890987654321L);
+            System.Text.Encoding.ASCII.GetBytes("-1234567890987654321").GetLong().Should().Be(-1234567890987654321L);
         }
 
         [TestMethod]
         public void negative_with_leading_zeros()
         {
-            Encoding.ASCII.GetBytes("-0001234567890987654321").GetLong().Should().Be(-1234567890987654321L);
+            System.Text.Encoding.ASCII.GetBytes("-0001234567890987654321").GetLong().Should().Be(-1234567890987654321L);
         }
     }
 }

--- a/HotFix.Test/utilities/reading/strings.cs
+++ b/HotFix.Test/utilities/reading/strings.cs
@@ -12,19 +12,19 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void empty()
         {
-            System.Text.Encoding.ASCII.GetBytes("").GetString().Should().Be("");
+            System.Text.Encoding.ASCII.GetBytes("").ReadString().Should().Be("");
         }
 
         [TestMethod]
         public void small()
         {
-            System.Text.Encoding.ASCII.GetBytes("XXX").GetString().Should().Be("XXX");
+            System.Text.Encoding.ASCII.GetBytes("XXX").ReadString().Should().Be("XXX");
         }
 
         [TestMethod]
         public void large()
         {
-            System.Text.Encoding.ASCII.GetBytes("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890,.;'#][/=-_+{}~@:?><").GetString().Should().Be("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890,.;'#][/=-_+{}~@:?><");
+            System.Text.Encoding.ASCII.GetBytes("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890,.;'#][/=-_+{}~@:?><").ReadString().Should().Be("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890,.;'#][/=-_+{}~@:?><");
         }
     }
 }

--- a/HotFix.Test/utilities/reading/strings.cs
+++ b/HotFix.Test/utilities/reading/strings.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Text;
 using FluentAssertions;
-using HotFix.Utilities;
+using HotFix.Encoding;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HotFix.Test.utilities.reading
@@ -12,19 +12,19 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void empty()
         {
-            Encoding.ASCII.GetBytes("").GetString().Should().Be("");
+            System.Text.Encoding.ASCII.GetBytes("").GetString().Should().Be("");
         }
 
         [TestMethod]
         public void small()
         {
-            Encoding.ASCII.GetBytes("XXX").GetString().Should().Be("XXX");
+            System.Text.Encoding.ASCII.GetBytes("XXX").GetString().Should().Be("XXX");
         }
 
         [TestMethod]
         public void large()
         {
-            Encoding.ASCII.GetBytes("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890,.;'#][/=-_+{}~@:?><").GetString().Should().Be("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890,.;'#][/=-_+{}~@:?><");
+            System.Text.Encoding.ASCII.GetBytes("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890,.;'#][/=-_+{}~@:?><").GetString().Should().Be("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890,.;'#][/=-_+{}~@:?><");
         }
     }
 }

--- a/HotFix.Test/utilities/writing/datetimes.cs
+++ b/HotFix.Test/utilities/writing/datetimes.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text;
 using FluentAssertions;
-using HotFix.Utilities;
+using HotFix.Encoding;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HotFix.Test.utilities.writing
@@ -22,7 +22,7 @@ namespace HotFix.Test.utilities.writing
         {
             var written = _buffer.WriteDateTime(1, DateTime.Parse("27/03/2017 15:45:13"));
 
-            Encoding.ASCII.GetString(_buffer).Should().Be("\0" + "20170327-15:45:13.000" + "\0");
+            System.Text.Encoding.ASCII.GetString(_buffer).Should().Be("\0" + "20170327-15:45:13.000" + "\0");
             written.Should().Be(21);
         }
 
@@ -31,7 +31,7 @@ namespace HotFix.Test.utilities.writing
         {
             var written = _buffer.WriteDateTime(1, DateTime.Parse("27/03/2017 15:45:13.123"));
 
-            Encoding.ASCII.GetString(_buffer).Should().Be("\0" + "20170327-15:45:13.123" + "\0");
+            System.Text.Encoding.ASCII.GetString(_buffer).Should().Be("\0" + "20170327-15:45:13.123" + "\0");
             written.Should().Be(21);
         }
 

--- a/HotFix.Test/utilities/writing/floats.cs
+++ b/HotFix.Test/utilities/writing/floats.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text;
 using FluentAssertions;
-using HotFix.Utilities;
+using HotFix.Encoding;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HotFix.Test.utilities.writing
@@ -22,7 +22,7 @@ namespace HotFix.Test.utilities.writing
         {
             var written = _buffer.WriteFloat(1, 0);
 
-            Encoding.ASCII.GetString(_buffer).Should().Be("\0" + "0.0" + "\0\0\0\0\0\0\0");
+            System.Text.Encoding.ASCII.GetString(_buffer).Should().Be("\0" + "0.0" + "\0\0\0\0\0\0\0");
             written.Should().Be(3);
         }
 
@@ -31,7 +31,7 @@ namespace HotFix.Test.utilities.writing
         {
             var written = _buffer.WriteFloat(1, 78.123456);
 
-            Encoding.ASCII.GetString(_buffer).Should().Be("\0" + "78.123456" + "\0");
+            System.Text.Encoding.ASCII.GetString(_buffer).Should().Be("\0" + "78.123456" + "\0");
             written.Should().Be(9);
         }
 
@@ -40,7 +40,7 @@ namespace HotFix.Test.utilities.writing
         {
             var written = _buffer.WriteFloat(1, -78.123456);
 
-            Encoding.ASCII.GetString(_buffer).Should().Be("\0" + "-78.123456");
+            System.Text.Encoding.ASCII.GetString(_buffer).Should().Be("\0" + "-78.123456");
             written.Should().Be(10);
         }
 

--- a/HotFix.Test/utilities/writing/ints.cs
+++ b/HotFix.Test/utilities/writing/ints.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Text;
 using FluentAssertions;
-using HotFix.Utilities;
+using HotFix.Encoding;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HotFix.Test.utilities.writing
@@ -22,7 +22,7 @@ namespace HotFix.Test.utilities.writing
         {
             var written = _buffer.WriteInt(3, 0);
 
-            Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0" + "0" + "\0\0\0\0\0\0\0");
+            System.Text.Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0" + "0" + "\0\0\0\0\0\0\0");
             written.Should().Be(1);
         }
 
@@ -31,7 +31,7 @@ namespace HotFix.Test.utilities.writing
         {
             var written = _buffer.WriteInt(3, 12345);
 
-            Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0" + "12345" + "\0\0\0");
+            System.Text.Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0" + "12345" + "\0\0\0");
             written.Should().Be(5);
         }
 
@@ -40,7 +40,7 @@ namespace HotFix.Test.utilities.writing
         {
             var written = _buffer.WriteInt(3, -12345);
 
-            Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0" + "-12345" + "\0\0");
+            System.Text.Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0" + "-12345" + "\0\0");
             written.Should().Be(6);
         }
 

--- a/HotFix.Test/utilities/writing/longs.cs
+++ b/HotFix.Test/utilities/writing/longs.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text;
 using FluentAssertions;
-using HotFix.Utilities;
+using HotFix.Encoding;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HotFix.Test.utilities.writing
@@ -22,7 +22,7 @@ namespace HotFix.Test.utilities.writing
         {
             var written = _buffer.WriteLong(3, 0);
 
-            Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0" + "0" + "\0\0\0\0\0\0\0");
+            System.Text.Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0" + "0" + "\0\0\0\0\0\0\0");
             written.Should().Be(1);
         }
 
@@ -31,7 +31,7 @@ namespace HotFix.Test.utilities.writing
         {
             var written = _buffer.WriteLong(3, 12345);
 
-            Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0" + "12345" + "\0\0\0");
+            System.Text.Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0" + "12345" + "\0\0\0");
             written.Should().Be(5);
         }
 
@@ -40,7 +40,7 @@ namespace HotFix.Test.utilities.writing
         {
             var written = _buffer.WriteLong(3, -12345);
 
-            Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0" + "-12345" + "\0\0");
+            System.Text.Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0" + "-12345" + "\0\0");
             written.Should().Be(6);
         }
 

--- a/HotFix.Test/utilities/writing/strings.cs
+++ b/HotFix.Test/utilities/writing/strings.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text;
 using FluentAssertions;
-using HotFix.Utilities;
+using HotFix.Encoding;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HotFix.Test.utilities.writing
@@ -22,7 +22,7 @@ namespace HotFix.Test.utilities.writing
         {
             var written = _buffer.WriteString(3, "");
 
-            Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0\0\0\0\0\0\0\0\0");
+            System.Text.Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0\0\0\0\0\0\0\0\0");
             written.Should().Be(0);
         }
 
@@ -31,7 +31,7 @@ namespace HotFix.Test.utilities.writing
         {
             var written = _buffer.WriteString(3, "string");
 
-            Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0" + "string" + "\0\0");
+            System.Text.Encoding.ASCII.GetString(_buffer).Should().Be("\0\0\0" + "string" + "\0\0");
             written.Should().Be(6);
         }
 

--- a/HotFix/Core/Field.cs
+++ b/HotFix/Core/Field.cs
@@ -1,5 +1,5 @@
 using System;
-using HotFix.Utilities;
+using HotFix.Encoding;
 
 namespace HotFix.Core
 {

--- a/HotFix/Core/Field.cs
+++ b/HotFix/Core/Field.cs
@@ -12,11 +12,11 @@ namespace HotFix.Core
         public int Length { get; }
         public int Checksum { get; }
 
-        public int AsInt => _message.GetInt(_value.Offset, _value.Length);
-        public long AsLong => _message.GetLong(_value.Offset, _value.Length);
-        public double AsFloat => _message.GetFloat(_value.Offset, _value.Length);
-        public string AsString => _message.GetString(_value.Offset, _value.Length);
-        public DateTime AsDateTime => _message.GetDateTime(_value.Offset, _value.Length);
+        public int AsInt => _message.ReadInt(_value.Offset, _value.Length);
+        public long AsLong => _message.ReadLong(_value.Offset, _value.Length);
+        public double AsFloat => _message.ReadFloat(_value.Offset, _value.Length);
+        public string AsString => _message.ReadString(_value.Offset, _value.Length);
+        public DateTime AsDateTime => _message.ReadDateTime(_value.Offset, _value.Length);
 
         public Field(byte[] message, int tag, Segment value, int length, int checksum)
         {

--- a/HotFix/Core/Message.cs
+++ b/HotFix/Core/Message.cs
@@ -216,7 +216,7 @@ namespace HotFix.Core
 
         public override string ToString()
         {
-            return Encoding.ASCII.GetString(Raw, 0, Length);
+            return System.Text.Encoding.ASCII.GetString(Raw, 0, Length);
         }
     }
 }

--- a/HotFix/Core/MessageWriter.cs
+++ b/HotFix/Core/MessageWriter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.Text;
-using HotFix.Utilities;
+using HotFix.Encoding;
 
 namespace HotFix.Core
 {
@@ -115,6 +114,6 @@ namespace HotFix.Core
             return checksum % 256;
         }
 
-        public override string ToString() => Encoding.ASCII.GetString(_buffer, 0, _end);
+        public override string ToString() => System.Text.Encoding.ASCII.GetString(_buffer, 0, _end);
     }
 }

--- a/HotFix/Core/Session.cs
+++ b/HotFix/Core/Session.cs
@@ -137,7 +137,7 @@ namespace HotFix.Core
             var trailer = $"10={((header + body).ToCharArray().Select(x => (int)x).Sum() % 256):D3}|".Replace("|", "\u0001");
 
             var message = header + body + trailer;
-            var msg = Encoding.UTF8.GetBytes(message);
+            var msg = System.Text.Encoding.UTF8.GetBytes(message);
 
             // TODO: Do we want to decrement the sequence number if creating/sending the message fails?
 

--- a/HotFix/Encoding/FIXEncoding.cs
+++ b/HotFix/Encoding/FIXEncoding.cs
@@ -14,9 +14,9 @@ namespace HotFix.Encoding
         /// <param name="source">The source string to parse.</param>
         /// <returns>The parsed integer.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int GetInt(this byte[] source)
+        public static int ReadInt(this byte[] source)
         {
-            return source.GetInt(0, source.Length);
+            return source.ReadInt(0, source.Length);
         }
 
         /// <summary>
@@ -30,7 +30,7 @@ namespace HotFix.Encoding
         /// <param name="count">The number of characters to parse.</param>
         /// <returns>The parsed integer.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int GetInt(this byte[] source, int offset, int count)
+        public static int ReadInt(this byte[] source, int offset, int count)
         {
             var value = 0;
             var sign = source[offset] == '-' ? -1 : +1;
@@ -59,9 +59,9 @@ namespace HotFix.Encoding
         /// <param name="source">The source string to parse.</param>
         /// <returns>The parsed integer.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long GetLong(this byte[] source)
+        public static long ReadLong(this byte[] source)
         {
-            return source.GetLong(0, source.Length);
+            return source.ReadLong(0, source.Length);
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace HotFix.Encoding
         /// <param name="count">The number of characters to parse.</param>
         /// <returns>The parsed integer.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long GetLong(this byte[] source, int offset, int count)
+        public static long ReadLong(this byte[] source, int offset, int count)
         {
             var value = 0L;
             var sign = source[offset] == '-' ? -1 : +1;
@@ -104,9 +104,9 @@ namespace HotFix.Encoding
         /// <param name="source">The source string to parse.</param>
         /// <returns>The parsed double.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double GetFloat(this byte[] source)
+        public static double ReadFloat(this byte[] source)
         {
-            return source.GetFloat(0, source.Length);
+            return source.ReadFloat(0, source.Length);
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace HotFix.Encoding
         /// <param name="count">The number of characters to parse.</param>
         /// <returns>The parsed double.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double GetFloat(this byte[] source, int offset, int count)
+        public static double ReadFloat(this byte[] source, int offset, int count)
         {
             var value = 0L;
             var exponent = 0d;
@@ -159,9 +159,9 @@ namespace HotFix.Encoding
         /// <param name="source">The source string to parse.</param>
         /// <returns>The parsed string.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string GetString(this byte[] source)
+        public static string ReadString(this byte[] source)
         {
-            return source.GetString(0, source.Length);
+            return source.ReadString(0, source.Length);
         }
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace HotFix.Encoding
         /// <param name="count">The number of characters to parse.</param>
         /// <returns>The parsed string.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe string GetString(this byte[] source, int offset, int count)
+        public static unsafe string ReadString(this byte[] source, int offset, int count)
         {
             char* chars = stackalloc char[count + 1];
 
@@ -200,9 +200,9 @@ namespace HotFix.Encoding
         /// <param name="source">The source string to parse.</param>
         /// <returns>The parsed datetime.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static DateTime GetDateTime(this byte[] source)
+        public static DateTime ReadDateTime(this byte[] source)
         {
-            return source.GetDateTime(0, source.Length);
+            return source.ReadDateTime(0, source.Length);
         }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace HotFix.Encoding
         /// <param name="count">The number of characters to parse.</param>
         /// <returns>The parsed datetime.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static DateTime GetDateTime(this byte[] source, int offset, int count)
+        public static DateTime ReadDateTime(this byte[] source, int offset, int count)
         {
             if (count != 17 && count != 21) throw new Exception("Not a valid datetime");
 
@@ -225,13 +225,13 @@ namespace HotFix.Encoding
             //if (source[14] != ':') throw new Exception("Not a valid datetime");
             //if (source[17] != '.') throw new Exception("Not a valid datetime");
 
-            var year = source.GetInt(offset + 00, 4);
-            var month = source.GetInt(offset + 04, 2);
-            var day = source.GetInt(offset + 06, 2);
-            var hour = source.GetInt(offset + 09, 2);
-            var minute = source.GetInt(offset + 12, 2);
-            var second = source.GetInt(offset + 15, 2);
-            var millis = count == 21 ? source.GetInt(offset + 18, 3) : 0;
+            var year = source.ReadInt(offset + 00, 4);
+            var month = source.ReadInt(offset + 04, 2);
+            var day = source.ReadInt(offset + 06, 2);
+            var hour = source.ReadInt(offset + 09, 2);
+            var minute = source.ReadInt(offset + 12, 2);
+            var second = source.ReadInt(offset + 15, 2);
+            var millis = count == 21 ? source.ReadInt(offset + 18, 3) : 0;
 
             return new DateTime(year, month, day, hour, minute, second, millis);
         }

--- a/HotFix/Encoding/FIXEncoding.cs
+++ b/HotFix/Encoding/FIXEncoding.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 
-namespace HotFix.Utilities
+namespace HotFix.Encoding
 {
-    public static class Parser
+    public static class FIXEncoding
     {
         /// <summary>
         /// Parses an integer (Int32) from the provided string.

--- a/HotFix/HotFix.csproj
+++ b/HotFix/HotFix.csproj
@@ -56,7 +56,7 @@
   <ItemGroup>
     <Compile Include="Core\MessageWriter.cs" />
     <Compile Include="Core\Configuration.cs" />
-    <Compile Include="Utilities\Parser.cs" />
+    <Compile Include="Encoding\FIXEncoding.cs" />
     <Compile Include="Core\Field.cs" />
     <Compile Include="Core\IConfiguration.cs" />
     <Compile Include="Core\Segment.cs" />

--- a/HotFix/Program.cs
+++ b/HotFix/Program.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Threading;
 using HotFix.Core;
 using HotFix.Transport;
-using HotFix.Utilities;
 
 namespace HotFix
 {


### PR DESCRIPTION
Refactoring:
- Renamed `parsing` to `encoding` as it seems more fitting
- Renamed encoding methods from `get` to `read` to improve read/write method parity