### PR TITLE
Completed dealing with test requests

### DIFF
--- a/HotFix.Specification/Specification.cs
+++ b/HotFix.Specification/Specification.cs
@@ -15,11 +15,6 @@ namespace HotFix.Specification
         public Type Exception { get; set; }
         public string Message { get; set; }
 
-        public Specification()
-        {
-
-        }
-
         public Specification Configure(IConfiguration configuration)
         {
             Configuration = configuration;
@@ -64,13 +59,14 @@ namespace HotFix.Specification
             {
                 if (Exception != null)
                 {
-                    if (Exception != exception.GetType())
-                        throw new AssertFailedException("The expected exception type was not thrown");
+                    if (exception.GetType() == typeof(DelightfullySuccessfulException))
+                        throw new AssertFailedException("The expected exception type was not thrwon. All instructions successfully executed instead");
 
-                    if (Message != null)
-                    {
-                        if (Message != exception.Message) throw new AssertFailedException("The thrown exception did not have the correct message");
-                    }
+                    if (Exception != exception.GetType())
+                        throw new AssertFailedException($"The expected exception type was not thrown. The type '{exception.GetType()}' was thrown instead");
+
+                    if (Message != null && Message != exception.Message)
+                        throw new AssertFailedException("The thrown exception did not have the correct message");
                 }
                 else
                 {

--- a/HotFix.Specification/Specification.cs
+++ b/HotFix.Specification/Specification.cs
@@ -60,10 +60,10 @@ namespace HotFix.Specification
                 if (Exception != null)
                 {
                     if (exception.GetType() == typeof(DelightfullySuccessfulException))
-                        throw new AssertFailedException("The expected exception type was not thrwon. All instructions successfully executed instead");
+                        throw new AssertFailedException($"The test expected an exception of type {Exception.FullName} but no exception was thrown");
 
                     if (Exception != exception.GetType())
-                        throw new AssertFailedException($"The expected exception type was not thrown. The type '{exception.GetType()}' was thrown instead");
+                        throw new AssertFailedException($"The test expected an exception of type {Exception.FullName} but an exception of type {exception.GetType().FullName} was thrown instead");
 
                     if (Message != null && Message != exception.Message)
                         throw new AssertFailedException("The thrown exception did not have the correct message");

--- a/HotFix.Specification/test_request/an_outbound_test_request.cs
+++ b/HotFix.Specification/test_request/an_outbound_test_request.cs
@@ -38,12 +38,106 @@ namespace HotFix.Specification.test_request
                     "! 20170623-14:51:51.000",
                     "! 20170623-14:51:52.000",
                     // The engine should send a test request since no inbound messages have been received
-                    "> 8=FIX.4.29=0007835=134=352=20170623-14:51:52.00049=Client56=Server112=63633826312000000010=150",
+                    "> 8=FIX.4.29=0007835=134=352=20170623-14:51:52.00049=Client56=Server112=63633826312000000010=150"
                 })
                 .Verify((engine, configuration) =>
                 {
                     configuration.InboundSeqNum.Should().Be(2);
                     configuration.OutboundSeqNum.Should().Be(4);
+                })
+                .Run();
+        }
+
+        [TestMethod]
+        public void terminates_the_session_when_no_message_is_received_for_twice_the_heartbeat_interval()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Version = "FIX.4.2",
+                    Sender = "Client",
+                    Target = "Server",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:45.012",
+                    "> 8=FIX.4.29=0007235=A34=152=20170623-14:51:45.01249=Client56=Server108=598=0141=Y10=094",
+                    "! 20170623-14:51:45.051",
+                    "< 8=FIX.4.29=7235=A34=149=Server52=20170623-14:51:45.05156=Client108=598=0141=Y10=209",
+                    "! 20170623-14:51:46.000",
+                    "! 20170623-14:51:47.000",
+                    "! 20170623-14:51:48.000",
+                    "! 20170623-14:51:49.000",
+                    "! 20170623-14:51:50.100",
+                    "> 8=FIX.4.29=0005535=034=252=20170623-14:51:50.10049=Client56=Server10=049",
+                    "! 20170623-14:51:50.056",
+                    "! 20170623-14:51:51.000",
+                    "! 20170623-14:51:52.000",
+                    // The engine should terminate the session after not receiving any messages
+                    "> 8=FIX.4.29=0007835=134=352=20170623-14:51:52.00049=Client56=Server112=63633826312000000010=150",
+                    "! 20170623-14:51:53.000",
+                    "! 20170623-14:51:54.000",
+                    "! 20170623-14:51:55.000",
+                    "! 20170623-14:51:56.000"
+                })
+                .Expect<EngineException>("Did not receive any messages for too long")
+                .Run();
+        }
+
+        [TestMethod]
+        public void is_reset_when_a_message_is_received_by_the_other_party()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Version = "FIX.4.2",
+                    Sender = "Client",
+                    Target = "Server",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:45.012",
+                    "> 8=FIX.4.29=0007235=A34=152=20170623-14:51:45.01249=Client56=Server108=598=0141=Y10=094",
+                    "! 20170623-14:51:45.051",
+                    "< 8=FIX.4.29=7235=A34=149=Server52=20170623-14:51:45.05156=Client108=598=0141=Y10=209",
+                    "! 20170623-14:51:46.000",
+                    "! 20170623-14:51:47.000",
+                    "! 20170623-14:51:48.000",
+                    "! 20170623-14:51:49.000",
+                    "! 20170623-14:51:50.100",
+                    "> 8=FIX.4.29=0005535=034=252=20170623-14:51:50.10049=Client56=Server10=049",
+                    "! 20170623-14:51:50.056",
+                    "! 20170623-14:51:51.000",
+                    "! 20170623-14:51:52.000",
+                    // The engine should send a test request since no inbound messages have been received
+                    "> 8=FIX.4.29=0007835=134=352=20170623-14:51:52.00049=Client56=Server112=63633826312000000010=150",
+                    "! 20170623-14:51:53.000",
+                    // The engine receives a message from the other side and so it should not terminate the session in the next 10 seconds
+                    "< 8=FIX.4.29=5535=034=249=Server52=20170623-14:51:53.00056=Client10=163",
+                    "! 20170623-14:51:54.000",
+                    "! 20170623-14:51:56.000",
+                    "! 20170623-14:51:58.000",
+                    // The engine should keep sending/receiving heartbeats normally
+                    "> 8=FIX.4.29=0005535=034=452=20170623-14:51:58.00049=Client56=Server10=058",
+                    "< 8=FIX.4.29=5535=034=349=Server52=20170623-14:51:58.00056=Client10=169",
+                    "! 20170623-14:52:00.000",
+                    "! 20170623-14:52:03.500",
+                    // The engine should keep sending/receiving heartbeats normally
+                    "> 8=FIX.4.29=0005535=034=552=20170623-14:52:03.50049=Client56=Server10=055",
+                    "< 8=FIX.4.29=5535=034=449=Server52=20170623-14:52:03.50056=Client10=166",
+                    "! 20170623-14:52:05.000",
+                    "! 20170623-14:52:06.000"
+                })
+                .Verify((engine, configuration) =>
+                {
+                    configuration.InboundSeqNum.Should().Be(5);
+                    configuration.OutboundSeqNum.Should().Be(6);
                 })
                 .Run();
         }

--- a/HotFix/Core/Configuration.cs
+++ b/HotFix/Core/Configuration.cs
@@ -24,5 +24,6 @@ namespace HotFix.Core
         public DateTime OutboundTimestamp { get; set; }
 
         public bool Synchronizing { get; set; }
+        public bool TestRequestPending { get; set; }
     }
 }

--- a/HotFix/Core/Engine.cs
+++ b/HotFix/Core/Engine.cs
@@ -40,6 +40,7 @@ namespace HotFix.Core
                     if (inbound[34].Is(configuration.InboundSeqNum))
                     {
                         configuration.Synchronizing = false;
+                        configuration.TestRequestPending = false;
 
                         // Process message
                         Console.WriteLine("Processing: " + inbound[35].AsString);
@@ -76,7 +77,16 @@ namespace HotFix.Core
 
                 if (Clock.Time - configuration.InboundTimestamp > TimeSpan.FromSeconds(configuration.HeartbeatInterval * 1.2))
                 {
-                    SendTestRequest(configuration, channel, outbound);
+                    if (Clock.Time - configuration.InboundTimestamp > TimeSpan.FromSeconds(configuration.HeartbeatInterval * 2))
+                    {
+                        throw new EngineException("Did not receive any messages for too long");
+                    }
+
+                    if (!configuration.TestRequestPending)
+                    {
+                        SendTestRequest(configuration, channel, outbound);
+                        configuration.TestRequestPending = true;
+                    }
                 }
 
                 inbound.Clear();

--- a/HotFix/Core/IConfiguration.cs
+++ b/HotFix/Core/IConfiguration.cs
@@ -24,5 +24,6 @@ namespace HotFix.Core
         DateTime OutboundTimestamp { get; set; }
 
         bool Synchronizing { get; set; }
+        bool TestRequestPending { get; set; }
     }
 }


### PR DESCRIPTION
- Completed dealing with test requests
  - engine does not keep sending test requests while the other end is not responding
  - session is terminated after two heartbeats' time of not receiving any messages
- Added more detail to the specification erroring