### PR TITLE
Fixed specification tests

### DIFF
--- a/HotFix.Specification/Specification.cs
+++ b/HotFix.Specification/Specification.cs
@@ -79,9 +79,9 @@ namespace HotFix.Specification
             {
                 Console.WriteLine();
 
-                for (var i = 1; i <= Instructions.Count; i++)
+                for (var i = 0; i < Instructions.Count; i++)
                 {
-                    Console.WriteLine($"{i}: {Instructions[i - 1]}");
+                    Console.WriteLine($"{i+1}: {Instructions[i]}");
 
                     if (i < harness.Step)
                         Console.WriteLine("   - SUCCEEDED");

--- a/HotFix.Specification/logon/logon.cs
+++ b/HotFix.Specification/logon/logon.cs
@@ -57,8 +57,7 @@ namespace HotFix.Specification.logon
                     "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:45.012|49=Client|56=Server|108=5|98=0|141=Y|10=094|",
                     "! 20170623-14:51:45.051",
                     // The engine should fail because the target sends an unexpected message type
-                    "< 8=FIX.4.2|9=55|35=0|34=1|49=Server|52=20170623-14:51:45.051|56=Client|10=169|",
-                    "! 20170623-14:51:46.000"
+                    "< 8=FIX.4.2|9=55|35=0|34=1|49=Server|52=20170623-14:51:45.051|56=Client|10=169|"
                 })
                 .Expect<EngineException>("Unexpected first message received (expected a logon)")
                 .Run();
@@ -84,8 +83,7 @@ namespace HotFix.Specification.logon
                     "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:45.012|49=Client|56=Server|108=5|98=0|141=Y|10=094|",
                     "! 20170623-14:51:45.051",
                     // The engine should fail because the response contains and unexpected begin string (8)
-                    "< 8=FIX.4.4|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Y|10=211|",
-                    "! 20170623-14:51:46.000"
+                    "< 8=FIX.4.4|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Y|10=211|"
                 })
                 .Expect<EngineException>("Unexpected begin string received")
                 .Run();
@@ -111,8 +109,7 @@ namespace HotFix.Specification.logon
                     "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:45.012|49=Client|56=Server|108=5|98=0|141=Y|10=094|",
                     "! 20170623-14:51:45.051",
                     // The engine should fail because the response contains an unexpected sender comp id (49)
-                    "< 8=FIX.4.2|9=72|35=A|34=1|49=XXXXXX|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Y|10=106|",
-                    "! 20170623-14:51:46.000"
+                    "< 8=FIX.4.2|9=72|35=A|34=1|49=XXXXXX|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Y|10=106|"
                 })
                 .Expect<EngineException>("Unexpected comp id received")
                 .Run();
@@ -138,8 +135,7 @@ namespace HotFix.Specification.logon
                     "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:45.012|49=Client|56=Server|108=5|98=0|141=Y|10=094|",
                     "! 20170623-14:51:45.051",
                     // The engine should fail because the response contains an unexpected target comp id (56)
-                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=XXXXXX|108=5|98=0|141=Y|10=130|",
-                    "! 20170623-14:51:46.000"
+                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=XXXXXX|108=5|98=0|141=Y|10=130|"
                 })
                 .Expect<EngineException>("Unexpected comp id received")
                 .Run();
@@ -165,8 +161,7 @@ namespace HotFix.Specification.logon
                     "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:45.012|49=Client|56=Server|108=5|98=0|141=Y|10=094|",
                     "! 20170623-14:51:45.051",
                     // The engine should fail because the response contains an unexpected heartbeat interval (108)
-                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=8|98=0|141=Y|10=212|",
-                    "! 20170623-14:51:46.000"
+                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=8|98=0|141=Y|10=212|"
                 })
                 .Expect<EngineException>("Unexpected heartbeat interval received")
                 .Run();
@@ -192,8 +187,7 @@ namespace HotFix.Specification.logon
                     "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:45.012|49=Client|56=Server|108=5|98=0|141=Y|10=094|",
                     "! 20170623-14:51:45.051",
                     // The engine should fail because the response contains an unexpected encryption method (98)
-                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=3|141=Y|10=212|",
-                    "! 20170623-14:51:46.000"
+                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=3|141=Y|10=212|"
                 })
                 .Expect<EngineException>("Unexpected encryption method received")
                 .Run();
@@ -219,8 +213,7 @@ namespace HotFix.Specification.logon
                     "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:45.012|49=Client|56=Server|108=5|98=0|141=Y|10=094|",
                     "! 20170623-14:51:45.051",
                     // The engine should fail because the response contains an unexpected reset on logon (141)
-                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Z|10=210|",
-                    "! 20170623-14:51:46.000"
+                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Z|10=210|"
                 })
                 .Expect<EngineException>("Unexpected reset on logon received")
                 .Run();
@@ -246,8 +239,7 @@ namespace HotFix.Specification.logon
                     "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:45.012|49=Client|56=Server|108=5|98=0|141=Y|10=094|",
                     "! 20170623-14:51:45.051",
                     // The engine should fail because the response contains a sequence number (34) that is too low
-                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Y|10=209|",
-                    "! 20170623-14:51:46.000"
+                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Y|10=209|"
                 })
                 .Expect<EngineException>("Sequence number too low")
                 .Run();

--- a/HotFix.Specification/resend_request/an_inbound_resend_request.cs
+++ b/HotFix.Specification/resend_request/an_inbound_resend_request.cs
@@ -30,8 +30,7 @@ namespace HotFix.Specification.resend_request
                     "< 8=FIX.4.2|9=73|35=A|34=10|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Y|10=002|",
                     "! 20170623-14:51:46.000",
                     "! 20170623-14:51:47.000",
-                    "< 8=FIX.4.2|9=65|35=2|34=11|49=Server|52=20170623-14:51:47.000|56=Client|7=5|16=8|10=096|",
-                    "! 20170623-14:51:51.000"
+                    "< 8=FIX.4.2|9=65|35=2|34=11|49=Server|52=20170623-14:51:47.000|56=Client|7=5|16=8|10=096|"
                 })
                 .Expect<EngineException>("Unsupported resend request received (partial gap fills are not supported)")
                 .Run();


### PR DESCRIPTION
- Fixed logic in specification step print function
- Removed redundant steps from failure tests
    - These steps are skipped anyway since the engine stops