### PR TITLE
Feature/acceptor

### DIFF
--- a/HotFix.Specification/HotFix.Specification.csproj
+++ b/HotFix.Specification/HotFix.Specification.csproj
@@ -60,11 +60,12 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="logon\as_acceptor.cs" />
     <Compile Include="VirtualTransport.cs" />
     <Compile Include="resend_request\an_inbound_resend_request.cs" />
     <Compile Include="test_request\an_inbound_test_request.cs" />
     <Compile Include="heartbeat\heartbeat.cs" />
-    <Compile Include="logon\logon.cs" />
+    <Compile Include="logon\as_initiator.cs" />
     <Compile Include="DelightfullySuccessfulException.cs" />
     <Compile Include="Specification.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/HotFix.Specification/Specification.cs
+++ b/HotFix.Specification/Specification.cs
@@ -54,7 +54,7 @@ namespace HotFix.Specification
 
             try
             {
-                session = engine.Initiate(Configuration);
+                session = engine.Open(Configuration);
 
                 session.Logon();
 
@@ -70,13 +70,13 @@ namespace HotFix.Specification
                 if (Exception != null)
                 {
                     if (exception.GetType() == typeof(DelightfullySuccessfulException))
-                        throw new AssertFailedException($"The test expected an exception of type {Exception.FullName} but no exception was thrown");
+                        throw new AssertFailedException($"The test expected an exception of type '{Exception.FullName}' but no exception was thrown");
 
                     if (Exception != exception.GetType())
-                        throw new AssertFailedException($"The test expected an exception of type {Exception.FullName} but an exception of type {exception.GetType().FullName} was thrown instead");
+                        throw new AssertFailedException($"The test expected an exception of type '{Exception.FullName}' but an exception of type '{exception.GetType().FullName}' was thrown instead", exception);
 
                     if (Message != null && Message != exception.Message)
-                        throw new AssertFailedException("The thrown exception did not have the correct message");
+                        throw new AssertFailedException("The thrown exception did not have the correct message", exception);
                 }
                 else
                 {

--- a/HotFix.Specification/logon/as_acceptor.cs
+++ b/HotFix.Specification/logon/as_acceptor.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using HotFix.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HotFix.Specification.logon
+{
+    [TestClass]
+    public class as_acceptor
+    {
+        [TestMethod]
+        public void fails_when_the_logon_request_is_not_received_in_the_allotted_time()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Acceptor,
+                    Version = "FIX.4.2",
+                    Sender = "Server",
+                    Target = "Client",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:40.000",
+                    "! 20170623-14:51:42.000",
+                    "! 20170623-14:51:44.000",
+                    "! 20170623-14:51:46.000",
+                    "! 20170623-14:51:48.000",
+                    // No logon request received from the target for over 10 seconds
+                    "! 20170623-14:51:50.000"
+                })
+                .Expect<EngineException>("Logon request not received on time")
+                .Run();
+        }
+
+        [TestMethod]
+        public void fails_when_the_logon_request_is_not_a_logon_message()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Acceptor,
+                    Version = "FIX.4.2",
+                    Sender = "Server",
+                    Target = "Client",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:40.000",
+                    // The engine should fail because the initiator sends an unexpected message type (35)
+                    "< 8=FIX.4.2|9=55|35=0|34=1|52=20170623-14:51:40.000|49=Client|56=Server|10=158|"
+                })
+                .Expect<EngineException>("Unexpected first message received (expected a logon)")
+                .Run();
+        }
+
+        [TestMethod]
+        public void fails_when_the_logon_request_contains_an_unexpected_beginstring()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Acceptor,
+                    Version = "FIX.4.2",
+                    Sender = "Server",
+                    Target = "Client",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:40.000",
+                    // The engine should fail because the initiator sends an unexpected begin string (8)
+                    "< 8=FIX.4.4|9=72|35=A|34=1|52=20170623-14:51:40.000|49=Client|56=Server|108=5|98=0|141=Y|10=200|"
+                })
+                .Expect<EngineException>("Unexpected begin string received")
+                .Run();
+        }
+
+        [TestMethod]
+        public void fails_when_the_logon_request_contains_an_unexpected_sender_compid()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Acceptor,
+                    Version = "FIX.4.2",
+                    Sender = "Server",
+                    Target = "Client",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:40.000",
+                    // The engine should fail because the initiator sends an unexpected sender comp id (49)
+                    "< 8=FIX.4.2|9=72|35=A|34=1|52=20170623-14:51:40.000|49=XXXXXX|56=Server|108=5|98=0|141=Y|10=119|"
+                })
+                .Expect<EngineException>("Unexpected comp id received")
+                .Run();
+        }
+
+        [TestMethod]
+        public void fails_when_the_logon_request_contains_an_unexpected_target_compid()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Acceptor,
+                    Version = "FIX.4.2",
+                    Sender = "Server",
+                    Target = "Client",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:40.000",
+                    // The engine should fail because the initiator sends an unexpected target comp id (56)
+                    "< 8=FIX.4.2|9=72|35=A|34=1|52=20170623-14:51:40.000|49=Client|56=XXXXXX|108=5|98=0|141=Y|10=095|"
+                })
+                .Expect<EngineException>("Unexpected comp id received")
+                .Run();
+        }
+
+        [TestMethod]
+        public void fails_when_the_logon_request_contains_an_unexpected_heartbeat_interval()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Acceptor,
+                    Version = "FIX.4.2",
+                    Sender = "Server",
+                    Target = "Client",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:40.000",
+                    // The engine should fail because the initiator sends an unexpected heartbeat interval (108)
+                    "< 8=FIX.4.2|9=72|35=A|34=1|52=20170623-14:51:40.000|49=Client|56=Server|108=8|98=0|141=Y|10=201|"
+                })
+                .Expect<EngineException>("Unexpected heartbeat interval received")
+                .Run();
+        }
+
+        [TestMethod]
+        public void fails_when_the_logon_request_contains_an_unexpected_encryption_method()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Acceptor,
+                    Version = "FIX.4.2",
+                    Sender = "Server",
+                    Target = "Client",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:40.000",
+                    // The engine should fail because the initiator sends an unexpected excryption method (98)
+                    "< 8=FIX.4.2|9=72|35=A|34=1|52=20170623-14:51:40.000|49=Client|56=Server|108=5|98=3|141=Y|10=201|"
+                })
+                .Expect<EngineException>("Unexpected encryption method received")
+                .Run();
+        }
+
+        [TestMethod]
+        public void fails_when_the_logon_request_contains_an_unexpected_reset_on_logon()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Acceptor,
+                    Version = "FIX.4.2",
+                    Sender = "Server",
+                    Target = "Client",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:40.000",
+                    // The engine should fail because the initiator sends an unexpected reset on logon (141)
+                    "< 8=FIX.4.2|9=72|35=A|34=1|52=20170623-14:51:40.000|49=Client|56=Server|108=5|98=0|141=N|10=187|"
+                })
+                .Expect<EngineException>("Unexpected reset on logon received")
+                .Run();
+        }
+
+        [TestMethod]
+        public void fails_when_the_logon_request_contains_a_sequence_number_that_is_too_low()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Acceptor,
+                    Version = "FIX.4.2",
+                    Sender = "Server",
+                    Target = "Client",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 5
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:40.000",
+                    // The engine should fail because the initiator sends a sequence number (34) that is too low
+                    "< 8=FIX.4.2|9=72|35=A|34=1|52=20170623-14:51:40.000|49=Client|56=Server|108=5|98=0|141=Y|10=198|"
+                })
+                .Expect<EngineException>("Sequence number too low")
+                .Run();
+        }
+
+        [TestMethod]
+        public void succeeds_but_sends_a_resend_request_when_the_logon_request_contains_a_sequence_number_that_is_too_high()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Acceptor,
+                    Version = "FIX.4.2",
+                    Sender = "Server",
+                    Target = "Client",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:40.000",
+                    // The initiator sends a logon request with a sequence number (34) that is too high
+                    "< 8=FIX.4.2|9=72|35=A|34=5|52=20170623-14:51:40.000|49=Client|56=Server|108=5|98=0|141=Y|10=202|",
+                    // The engine sends a logon response
+                    "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:40.000|49=Server|56=Client|108=5|98=0|141=Y|10=086|",
+                    // The engine sends a resend request for any missed messages (sequence number 1 onwards)
+                    "> 8=FIX.4.2|9=00064|35=2|34=2|52=20170623-14:51:40.000|49=Server|56=Client|7=1|16=0|10=172|"
+                })
+                .Verify((engine, configuration) =>
+                {
+                    engine.State.InboundSeqNum.Should().Be(1);
+                    engine.State.OutboundSeqNum.Should().Be(3);
+                    engine.State.Synchronizing.Should().Be(true);
+                })
+                .Run();
+        }
+
+        [TestMethod]
+        public void succeeds_when_a_valid_logon_request_is_received_promptly_with_the_expected_sequence_numbers()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Acceptor,
+                    Version = "FIX.4.2",
+                    Sender = "Server",
+                    Target = "Client",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:40.000",
+                    // The initiator sends a logon request with a sequence number (34) that is too high
+                    "< 8=FIX.4.2|9=72|35=A|34=1|52=20170623-14:51:40.000|49=Client|56=Server|108=5|98=0|141=Y|10=198|",
+                    // The engine sends a logon response
+                    "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:40.000|49=Server|56=Client|108=5|98=0|141=Y|10=086|",
+                    "! 20170623-14:51:42.000"
+                })
+                .Verify((engine, configuration) =>
+                {
+                    engine.State.InboundSeqNum.Should().Be(2);
+                    engine.State.OutboundSeqNum.Should().Be(2);
+                })
+                .Run();
+        }
+    }
+}

--- a/HotFix.Specification/logon/as_initiator.cs
+++ b/HotFix.Specification/logon/as_initiator.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace HotFix.Specification.logon
 {
     [TestClass]
-    public class logon
+    public class as_initiator
     {
         [TestMethod]
         public void fails_when_the_response_is_not_received_in_the_allotted_time()

--- a/HotFix/Core/Configuration.cs
+++ b/HotFix/Core/Configuration.cs
@@ -4,6 +4,8 @@ namespace HotFix.Core
 {
     public class Configuration : IConfiguration
     {
+        public Role Role { get; set; }
+
         public int HeartbeatInterval { get; set; }
 
         public string Version { get; set; } = "FIX.4.2";

--- a/HotFix/Core/Engine.cs
+++ b/HotFix/Core/Engine.cs
@@ -12,10 +12,10 @@ namespace HotFix.Core
         public Engine()
         {
             Clocks = c => new RealTimeClock();
-            Transports = c => new TcpTransport(c.Host, c.Port);
+            Transports = c => TcpTransport.Create(c.Role == Role.Acceptor, c.Host, c.Port);
         }
 
-        public Session Initiate(IConfiguration configuration)
+        public Session Open(IConfiguration configuration)
         {
             var clock = Clocks(configuration);
             var transport = Transports(configuration);

--- a/HotFix/Core/IConfiguration.cs
+++ b/HotFix/Core/IConfiguration.cs
@@ -4,6 +4,8 @@ namespace HotFix.Core
 {
     public interface IConfiguration
     {
+        Role Role { get; set; }
+
         int HeartbeatInterval { get; set; }
 
         string Version { get; set; }

--- a/HotFix/Core/Role.cs
+++ b/HotFix/Core/Role.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace HotFix.Core
+{
+    public enum Role
+    {
+        Initiator = 0,
+        Acceptor = 1
+    }
+}

--- a/HotFix/HotFix.csproj
+++ b/HotFix/HotFix.csproj
@@ -56,6 +56,7 @@
   <ItemGroup>
     <Compile Include="Core\Channel.cs" />
     <Compile Include="Core\Engine.cs" />
+    <Compile Include="Core\Role.cs" />
     <Compile Include="Core\Session.cs" />
     <Compile Include="Core\FIXMessageWriter.cs" />
     <Compile Include="Core\Configuration.cs" />

--- a/HotFix/Program.cs
+++ b/HotFix/Program.cs
@@ -1,39 +1,225 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using HotFix.Core;
-using HotFix.Transport;
 
 namespace HotFix
 {
     public class Program
     {
+        public static Engine Engine;
+        public static Session Acceptor;
+        public static Session Initiator;
+
+        public static bool Running = true;
+        public static List<long> Timings = new List<long>(10000000);
+
         public static void Main(string[] args)
         {
-            var configuration = new Configuration
+            Console.WriteLine("Performance benchmark");
+            Console.WriteLine();
+            Console.WriteLine(
+                "This performance benchmark will run an acceptor and an initiator on two background threads " +
+                "connected over loopback via tcp transport. We measure the overall one-way path of messaging " +
+                "from the acceptor to the initiator, including: \n\n" +
+                "user code -> encoding -> sending -> receiving -> decoding -> user code");
+            Console.WriteLine();
+            Console.WriteLine("Note: You can play with the message fields to see how message size affect performance");
+            Console.WriteLine();
+            Console.WriteLine("Press any key to run the test...");
+            Console.ReadKey();
+            Console.Clear();
+
+            DateTime start;
+            Console.WriteLine($"Started at {start = DateTime.UtcNow}");
+
+            Engine = new Engine();
+
+            // Configure acceptor session
+            var acceptor = new Configuration
             {
-                Host = "localhost",
+                Role = Role.Acceptor,
+                Host = "127.0.0.1",
+                Port = 1234,
+                Sender = "TARGET",
+                Target = "DAEV",
+                InboundSeqNum = 1,
+                OutboundSeqNum = 1,
+                HeartbeatInterval = 5
+            };
+
+            // Configure initiator session
+            var initiator = new Configuration
+            {
+                Role = Role.Initiator,
+                Host = "127.0.0.1",
                 Port = 1234,
                 Sender = "DAEV",
                 Target = "TARGET",
                 InboundSeqNum = 1,
                 OutboundSeqNum = 1,
-                HeartbeatInterval = 5,
-                InboundBufferSize = 65536,
-                OutboundBufferSize = 65536
+                HeartbeatInterval = 5
             };
 
-            var engine = new Engine();
+            // Create and start acceptor session on background thread
+            Task.Factory.StartNew(() =>
+            {
+                try
+                {
+                    Acceptor = Engine.Open(acceptor);
+                    Acceptor.Logon();
 
-            engine.Initiate(configuration);
+                    Console.WriteLine("Acceptor logged on");
 
-            //var transport = new TcpTransport(configuration.Host, configuration.Port);
-            //var session = new FIXSession(transport, configuration);
+                    while (Running)
+                    {
+                        Acceptor.Receive();
 
-            //session.Run();
+                        var message = Acceptor.Outbound;
 
-            Console.WriteLine("Session has ended, press any key to exit");
+                        for (var i = 0; i < 100; i++)
+                        {
+                            message.Prepare("X");
+                            message.Set(34, Acceptor.State.OutboundSeqNum);
+                            message.Set(52, Acceptor.Clock.Time);
+                            message.Set(49, Acceptor.Configuration.Sender);
+                            message.Set(56, Acceptor.Configuration.Target);
+                            message.Set(999, Acceptor.Clock.Time.Ticks);
+                            message.Build();
+
+                            Acceptor.Send(Acceptor.State, Acceptor.Channel, message);
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"Acceptor failed because: {e.Message}");
+                    Console.WriteLine();
+                    Console.WriteLine(e);
+                }
+            }, TaskCreationOptions.LongRunning);
+
+            Thread.Sleep(1000);
+
+            // Start initiator session on background thread
+            Task.Factory.StartNew(() =>
+            {
+                try
+                {
+                    Initiator = Engine.Open(initiator);
+                    Initiator.Logon();
+
+                    Console.WriteLine("Initiator logged on");
+
+                    while (Running)
+                    {
+                        Initiator.Receive();
+
+                        if (Initiator.Inbound.Valid && Initiator.Inbound[35].Is("X"))
+                        {
+                            // Take measurement in microseconds - application send to application receive time (one way end-to-end)
+                            Timings.Add((Initiator.Clock.Time.Ticks - Initiator.Inbound[999].AsLong) / 10);
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"Initiator failed because: {e.Message}");
+                    Console.WriteLine();
+                    Console.WriteLine(e);
+                }
+            }, TaskCreationOptions.LongRunning);
+
+            Console.WriteLine();
+            Console.WriteLine("Press any key to end the test...");
+            Console.WriteLine();
+
+            Thread.Sleep(3000);
+
+            GC.Collect();
+            GC.Collect();
+            GC.Collect();
+
+            var gc0 = GC.CollectionCount(0);
+            var gc1 = GC.CollectionCount(1);
+            var gc2 = GC.CollectionCount(2);
+
+            Console.ReadLine();
+
+            Running = false;
+
+            Thread.Sleep(100);
+
+            gc0 = GC.CollectionCount(0) - gc0;
+            gc1 = GC.CollectionCount(1) - gc1;
+            gc2 = GC.CollectionCount(2) - gc2;
+
+            // Skip first few measurements (exclude jit and optimize passes)
+            Timings = Timings.Skip(1000).ToList();
+
+            Console.Clear();
+            Console.WriteLine($"Count:    {Timings.Count}");
+            Console.WriteLine($"Duration: {DateTime.UtcNow - start}");
+            Console.WriteLine();
+            Console.WriteLine($"End to end one-way");
+            Console.WriteLine($"------------------");
+            Console.WriteLine($"Latency max: {$"{Timings.Max():N}",14} micros");
+            Console.WriteLine($"        avg: {$"{Timings.Average():N}",14} micros");
+            Console.WriteLine($"        min: {$"{Timings.Min():N}",14} micros");
+            Console.WriteLine();
+            Console.WriteLine($"        99%: {$"{Percentile(Timings, 0.99):N}",14} micros");
+            Console.WriteLine($"        90%: {$"{Percentile(Timings, 0.90):N}",14} micros");
+            Console.WriteLine($"        50%: {$"{Percentile(Timings, 0.50):N}",14} micros");
+            Console.WriteLine();
+            Console.WriteLine($"        std: {$"{StdDev(Timings):N}",14} micros");
+            Console.WriteLine();
+            Console.WriteLine($"Garbage col:");
+            Console.WriteLine($"         G0: {gc0}");
+            Console.WriteLine($"         G1: {gc1}");
+            Console.WriteLine($"         G2: {gc2}");
+            Console.WriteLine();
+
+            Console.WriteLine("Test finished, press any key to exit...");
             Console.ReadKey();
         }
-    }
 
-    
+        public static long Percentile(List<long> sequence, double excelPercentile)
+        {
+            var sorted = sequence.OrderBy(x => x).ToList();
+
+            var N = sorted.Count();
+            var n = (N - 1) * excelPercentile + 1;
+            // Another method: double n = (N + 1) * excelPercentile; 
+            if (n == 1d) return sorted[0];
+            else if (n == N) return sorted[N - 1];
+            else
+            {
+                var k = (int)n;
+                var d = n - k;
+                return (long)(sorted[k - 1] + d * (sorted[k] - sorted[k - 1]));
+            }
+        }
+
+        public static double StdDev(List<long> values)
+        {
+            var ret = (double)0;
+            var count = values.Count();
+
+            if (count > 1)
+            {
+                // Compute the Average 
+                var avg = values.Average();
+
+                // Perform the Sum of (value-avg)^2 
+                var sum = values.Sum(d => (d - avg) * (d - avg));
+
+                // Put it all together 
+                ret = Math.Sqrt(sum / count);
+            }
+
+            return ret;
+        }
+    }
 }


### PR DESCRIPTION
- Added role concept to configuration
- Enabled running engine as acceptor over tcp
    - Added client/server capability to tcp transport
        - Client semantics are to simply connect and start
        - Server semantics are to wait for inbound connection and then start
    - Added role check in engine transport factory to start the transport in the relevant mode
    - Modified specifications to use the engine appropriately
- Added acceptor support to session
    - Session now supports running as acceptor
        - Uses configured role to decide how to log on
        - Added acceptor logon handling
            - Wait for logon request for up to 10 seconds
            - Validate and respond with a logon response
            - Optionally, send resend request if seqnum too high
    - Added specification tests for logon as acceptor/initiator
- Added realistic performance benchmark
    - The main program now runs a realistic benchmark
        1. Starts an initiator and an acceptor
        2. Acceptor sends messages containing high resolution timestamps
        3.  Initiator compares the received timestamp to the current time and saves the delta for analysis
    - The benchmark displays min, max, average, percentiles as well as standard deviation
    - *Note: These numbers are not summarised and include each and every measurement so the statistics should be very precise...*