### PR TITLE
Feature/engine settings

### DIFF
--- a/HotFix.Benchmark/suites/session/session_receive.cs
+++ b/HotFix.Benchmark/suites/session/session_receive.cs
@@ -65,7 +65,7 @@ namespace HotFix.Benchmark.suites.session
             };
 
             Transport = new Canned();
-            Session = new Session(Configuration, new RealTimeClock(), Transport);
+            Session = new Session(Configuration, new RealTimeClock(), Transport, 65536, 4096, 1024);
         }
 
         public Configuration Configuration;

--- a/HotFix/Core/Channel.cs
+++ b/HotFix/Core/Channel.cs
@@ -14,11 +14,11 @@ namespace HotFix.Core
 
         public ITransport Transport { get; }
 
-        public Channel(ITransport transport)
+        public Channel(ITransport transport, int buffer)
         {
             Transport = transport;
 
-            _buffer = new byte[65536];
+            _buffer = new byte[buffer];
         }
 
         public bool Read(FIXMessage message)

--- a/HotFix/Core/Engine.cs
+++ b/HotFix/Core/Engine.cs
@@ -6,21 +6,42 @@ namespace HotFix.Core
 {
     public class Engine
     {
+        /// <summary> A factory method for clocks </summary>
         public Func<IConfiguration, IClock> Clocks { get; set; }
+        /// <summary> A factory method for transports </summary>
         public Func<IConfiguration, ITransport> Transports { get; set; }
+
+        /// <summary> Gets or sets the buffer size used for transport and session buffering </summary>
+        public int BufferSize { get; set; }
+        /// <summary> Gets or sets the maximum length of fix messages </summary>
+        public int MaxMessageLength { get; set; }
+        /// <summary> Gets or sets the maximum fields in fix messages </summary>
+        public int MaxMessageFields { get; set; }
 
         public Engine()
         {
             Clocks = c => new RealTimeClock();
             Transports = c => TcpTransport.Create(c.Role == Role.Acceptor, c.Host, c.Port);
+
+            BufferSize = 65536;
+            MaxMessageLength = 4096;
+            MaxMessageFields = 1024;
         }
 
+        /// <summary>
+        /// Opens a session along with the relevant transport
+        /// <remarks>
+        /// This is a blocking operation which directly connects the transport
+        /// </remarks>
+        /// </summary>
+        /// <param name="configuration">The session configuration</param>
+        /// <returns>The connected session</returns>
         public Session Open(IConfiguration configuration)
         {
             var clock = Clocks(configuration);
             var transport = Transports(configuration);
 
-            return new Session(configuration, clock, transport);
+            return new Session(configuration, clock, transport, BufferSize, MaxMessageLength, MaxMessageFields);
         }
     }
 }

--- a/HotFix/Core/FIXMessage.cs
+++ b/HotFix/Core/FIXMessage.cs
@@ -14,10 +14,10 @@ namespace HotFix.Core
 
         public bool Valid { get; private set; }
 
-        public FIXMessage()
+        public FIXMessage(int length = 4096, int fields = 1024)
         {
-            Raw = new byte[4096];
-            Fields = new FIXField[1000];
+            Raw = new byte[length];
+            Fields = new FIXField[fields];
         }
 
         /// <summary>

--- a/HotFix/Core/Session.cs
+++ b/HotFix/Core/Session.cs
@@ -15,12 +15,12 @@ namespace HotFix.Core
         public FIXMessage Inbound;
         public FIXMessageWriter Outbound;
 
-        public Session(IConfiguration configuration, IClock clock, ITransport transport)
+        public Session(IConfiguration configuration, IClock clock, ITransport transport, int bufferSize, int maxMessageLength, int maxMessageFields)
         {
             Clock = clock;
             Configuration = configuration;
 
-            Channel = new Channel(transport);
+            Channel = new Channel(transport, bufferSize);
             State = new State
             {
                 InboundSeqNum = configuration.InboundSeqNum,
@@ -29,8 +29,8 @@ namespace HotFix.Core
                 OutboundTimestamp = clock.Time
             };
 
-            Inbound = new FIXMessage();
-            Outbound = new FIXMessageWriter(1024, configuration.Version);
+            Inbound = new FIXMessage(maxMessageLength, maxMessageFields);
+            Outbound = new FIXMessageWriter(maxMessageLength, configuration.Version);
         }
 
         public void Logon()


### PR DESCRIPTION
- Engine now has settings (properties)
    - `Buffer size`: the buffer size for session and transport buffers
    - `Message length`: the maximum length of fix messages
    - `Message fields`: the maximum number of fields in a fix message
- Settings are passed through to the relevant underlying types