### PR TITLE
Feature/logout

### DIFF
--- a/HotFix.Specification/HotFix.Specification.csproj
+++ b/HotFix.Specification/HotFix.Specification.csproj
@@ -61,7 +61,8 @@
   </Choose>
   <ItemGroup>
     <Compile Include="logon\as_acceptor.cs" />
-    <Compile Include="logout\a_logout.cs" />
+    <Compile Include="logout\an_initiated_logout.cs" />
+    <Compile Include="logout\an_uninitiated_logout.cs" />
     <Compile Include="VirtualTransport.cs" />
     <Compile Include="resend_request\an_inbound_resend_request.cs" />
     <Compile Include="test_request\an_inbound_test_request.cs" />

--- a/HotFix.Specification/HotFix.Specification.csproj
+++ b/HotFix.Specification/HotFix.Specification.csproj
@@ -61,6 +61,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="logon\as_acceptor.cs" />
+    <Compile Include="logout\a_logout.cs" />
     <Compile Include="VirtualTransport.cs" />
     <Compile Include="resend_request\an_inbound_resend_request.cs" />
     <Compile Include="test_request\an_inbound_test_request.cs" />

--- a/HotFix.Specification/Specification.cs
+++ b/HotFix.Specification/Specification.cs
@@ -9,7 +9,6 @@ namespace HotFix.Specification
     {
         public IConfiguration Configuration { get; set; }
         public List<string> Instructions { get; set; }
-        public bool LogoutRequested { get; set; }
 
         public Action<Session, IConfiguration, VirtualTransport> Verification { get; set; }
 
@@ -48,7 +47,7 @@ namespace HotFix.Specification
         public Specification Run()
         {
             var clock = new VirtualClock();
-            var transport = new VirtualTransport(clock, Instructions, () => LogoutRequested = true);
+            var transport = new VirtualTransport(clock, Instructions);
             var engine = new Engine { Clocks = c => clock, Transports = c => transport };
 
             var session = (Session) null;
@@ -57,9 +56,10 @@ namespace HotFix.Specification
             {
                 using (session = engine.Open(Configuration))
                 {
+                    transport.Session = session;
                     session.Logon();
 
-                    while (session.Active && !LogoutRequested)
+                    while (session.Active)
                     {
                         session.Receive();
                     }

--- a/HotFix.Specification/Specification.cs
+++ b/HotFix.Specification/Specification.cs
@@ -9,8 +9,9 @@ namespace HotFix.Specification
     {
         public IConfiguration Configuration { get; set; }
         public List<string> Instructions { get; set; }
+        public bool LogoutRequested { get; set; }
 
-        public Action<Session, IConfiguration> Verification { get; set; }
+        public Action<Session, IConfiguration, VirtualTransport> Verification { get; set; }
 
         public Type Exception { get; set; }
         public string Message { get; set; }
@@ -29,7 +30,7 @@ namespace HotFix.Specification
             return this;
         }
 
-        public Specification Verify(Action<Session, IConfiguration> verification)
+        public Specification Verify(Action<Session, IConfiguration, VirtualTransport> verification)
         {
             Verification = verification;
 
@@ -47,21 +48,29 @@ namespace HotFix.Specification
         public Specification Run()
         {
             var clock = new VirtualClock();
-            var transport = new VirtualTransport(clock, Instructions);
+            var transport = new VirtualTransport(clock, Instructions, () => LogoutRequested = true);
             var engine = new Engine { Clocks = c => clock, Transports = c => transport };
 
             var session = (Session) null;
 
             try
             {
-                session = engine.Open(Configuration);
-
-                session.Logon();
-
-                while (true)
+                using (session = engine.Open(Configuration))
                 {
-                    session.Receive();
+                    session.Logon();
+
+                    while (session.Active && !LogoutRequested)
+                    {
+                        session.Receive();
+                    }
+
+                    session.Logout();
                 }
+
+                throw 
+                    transport.Step == transport.Instructions.Count ? 
+                    new DelightfullySuccessfulException() : 
+                    new Exception("Session ended prematurely");
             }
             catch (Exception exception)
             {
@@ -80,7 +89,7 @@ namespace HotFix.Specification
                 {
                     if (exception.GetType() != typeof(DelightfullySuccessfulException)) throw;
 
-                    Verification.Invoke(session, Configuration);
+                    Verification.Invoke(session, Configuration, transport);
                 }
             }
             finally
@@ -102,5 +111,6 @@ namespace HotFix.Specification
 
             return this;
         }
+
     }
 }

--- a/HotFix.Specification/VirtualTransport.cs
+++ b/HotFix.Specification/VirtualTransport.cs
@@ -9,13 +9,16 @@ namespace HotFix.Specification
     {
         public VirtualClock Clock { get; }
         public List<string> Instructions { get; }
+        public Action RequestLogout { get; }
 
         public int Step { get; private set; }
+        public bool Disposed { get; private set; }
 
-        public VirtualTransport(VirtualClock clock, List<string> instructions)
+        public VirtualTransport(VirtualClock clock, List<string> instructions, Action requestLogout)
         {
             Clock = clock;
             Instructions = instructions;
+            RequestLogout = requestLogout;
 
             var instruction = NextInstruction();
 
@@ -43,6 +46,9 @@ namespace HotFix.Specification
                         return instruction.Length - 2;
                     case '>':
                         throw new Exception($"Outbound message expected but not received: {instruction}");
+                    case 'X':
+                        RequestLogout();
+                        return 0;
                     default:
                         throw new Exception($"Unrecognised instruction found in scenario: {instruction}");
                 }
@@ -77,7 +83,7 @@ namespace HotFix.Specification
 
         public void Dispose()
         {
-
+            Disposed = true;
         }
     }
 }

--- a/HotFix.Specification/VirtualTransport.cs
+++ b/HotFix.Specification/VirtualTransport.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using FluentAssertions;
+using HotFix.Core;
 using HotFix.Transport;
 
 namespace HotFix.Specification
@@ -9,16 +10,15 @@ namespace HotFix.Specification
     {
         public VirtualClock Clock { get; }
         public List<string> Instructions { get; }
-        public Action RequestLogout { get; }
+        public Session Session { get; set; }
 
         public int Step { get; private set; }
         public bool Disposed { get; private set; }
 
-        public VirtualTransport(VirtualClock clock, List<string> instructions, Action requestLogout)
+        public VirtualTransport(VirtualClock clock, List<string> instructions)
         {
             Clock = clock;
             Instructions = instructions;
-            RequestLogout = requestLogout;
 
             var instruction = NextInstruction();
 
@@ -47,7 +47,7 @@ namespace HotFix.Specification
                     case '>':
                         throw new Exception($"Outbound message expected but not received: {instruction}");
                     case 'X':
-                        RequestLogout();
+                        Session.Logout();
                         return 0;
                     default:
                         throw new Exception($"Unrecognised instruction found in scenario: {instruction}");

--- a/HotFix.Specification/heartbeat/heartbeat.cs
+++ b/HotFix.Specification/heartbeat/heartbeat.cs
@@ -43,10 +43,10 @@ namespace HotFix.Specification.heartbeat
                     "< 8=FIX.4.2|9=55|35=0|34=2|49=Server|52=20170623-14:51:50.056|56=Client|10=171|",
                     "! 20170623-14:51:51.000"
                 })
-                .Verify((engine, configuration) =>
+                .Verify((session, configuration, _) =>
                 {
-                    engine.State.InboundSeqNum.Should().Be(3);
-                    engine.State.OutboundSeqNum.Should().Be(3);
+                    session.State.InboundSeqNum.Should().Be(3);
+                    session.State.OutboundSeqNum.Should().Be(3);
                 })
                 .Run();
         }

--- a/HotFix.Specification/logon/as_acceptor.cs
+++ b/HotFix.Specification/logon/as_acceptor.cs
@@ -230,6 +230,34 @@ namespace HotFix.Specification.logon
         }
 
         [TestMethod]
+        public void fails_when_a_logon_request_is_received_while_already_successfully_logged_on()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Acceptor,
+                    Version = "FIX.4.2",
+                    Sender = "Server",
+                    Target = "Client",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:40.000",
+                    // The initiator sends a logon request with a sequence number (34) that is as expected
+                    "< 8=FIX.4.2|9=72|35=A|34=1|52=20170623-14:51:40.000|49=Client|56=Server|108=5|98=0|141=Y|10=198|",
+                    // The engine sends a logon response
+                    "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:40.000|49=Server|56=Client|108=5|98=0|141=Y|10=086|",
+                    // The initiator sends another logon request after the logon has already succeeded
+                    "< 8=FIX.4.2|9=72|35=A|34=2|52=20170623-14:51:40.000|49=Client|56=Server|108=5|98=0|141=Y|10=199|"
+                })
+                .Expect<EngineException>("Logon message received while already logged on")
+                .Run();
+        }
+
+        [TestMethod]
         public void succeeds_but_sends_a_resend_request_when_the_logon_request_contains_a_sequence_number_that_is_too_high()
         {
             new Specification()
@@ -279,7 +307,7 @@ namespace HotFix.Specification.logon
                 .Steps(new List<string>
                 {
                     "! 20170623-14:51:40.000",
-                    // The initiator sends a logon request with a sequence number (34) that is too high
+                    // The initiator sends a logon request with a sequence number (34) that is as expected
                     "< 8=FIX.4.2|9=72|35=A|34=1|52=20170623-14:51:40.000|49=Client|56=Server|108=5|98=0|141=Y|10=198|",
                     // The engine sends a logon response
                     "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:40.000|49=Server|56=Client|108=5|98=0|141=Y|10=086|",

--- a/HotFix.Specification/logon/as_acceptor.cs
+++ b/HotFix.Specification/logon/as_acceptor.cs
@@ -281,11 +281,11 @@ namespace HotFix.Specification.logon
                     // The engine sends a resend request for any missed messages (sequence number 1 onwards)
                     "> 8=FIX.4.2|9=00064|35=2|34=2|52=20170623-14:51:40.000|49=Server|56=Client|7=1|16=0|10=172|"
                 })
-                .Verify((engine, configuration) =>
+                .Verify((session, configuration, _) =>
                 {
-                    engine.State.InboundSeqNum.Should().Be(1);
-                    engine.State.OutboundSeqNum.Should().Be(3);
-                    engine.State.Synchronizing.Should().Be(true);
+                    session.State.InboundSeqNum.Should().Be(1);
+                    session.State.OutboundSeqNum.Should().Be(3);
+                    session.State.Synchronizing.Should().Be(true);
                 })
                 .Run();
         }
@@ -313,10 +313,10 @@ namespace HotFix.Specification.logon
                     "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:40.000|49=Server|56=Client|108=5|98=0|141=Y|10=086|",
                     "! 20170623-14:51:42.000"
                 })
-                .Verify((engine, configuration) =>
+                .Verify((session, configuration, _) =>
                 {
-                    engine.State.InboundSeqNum.Should().Be(2);
-                    engine.State.OutboundSeqNum.Should().Be(2);
+                    session.State.InboundSeqNum.Should().Be(2);
+                    session.State.OutboundSeqNum.Should().Be(2);
                 })
                 .Run();
         }

--- a/HotFix.Specification/logon/as_initiator.cs
+++ b/HotFix.Specification/logon/as_initiator.cs
@@ -309,11 +309,11 @@ namespace HotFix.Specification.logon
                     "> 8=FIX.4.2|9=00064|35=2|34=2|52=20170623-14:51:45.051|49=Client|56=Server|7=5|16=0|10=187|",
                     "! 20170623-14:51:46.000"
                 })
-                .Verify((engine, configuration) =>
+                .Verify((session, configuration, _) =>
                 {
-                    engine.State.InboundSeqNum.Should().Be(5);
-                    engine.State.OutboundSeqNum.Should().Be(3);
-                    engine.State.Synchronizing.Should().Be(true);
+                    session.State.InboundSeqNum.Should().Be(5);
+                    session.State.OutboundSeqNum.Should().Be(3);
+                    session.State.Synchronizing.Should().Be(true);
                 })
                 .Run();
         }
@@ -342,10 +342,10 @@ namespace HotFix.Specification.logon
                     "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Y|10=209|",
                     "! 20170623-14:51:46.000"
                 })
-                .Verify((engine, configuration) =>
+                .Verify((session, configuration, _) =>
                 {
-                    engine.State.InboundSeqNum.Should().Be(2);
-                    engine.State.OutboundSeqNum.Should().Be(2);
+                    session.State.InboundSeqNum.Should().Be(2);
+                    session.State.OutboundSeqNum.Should().Be(2);
                 })
                 .Run();
         }

--- a/HotFix.Specification/logon/as_initiator.cs
+++ b/HotFix.Specification/logon/as_initiator.cs
@@ -255,6 +255,35 @@ namespace HotFix.Specification.logon
         }
 
         [TestMethod]
+        public void fails_when_a_logon_request_is_received_while_already_successfully_logged_on()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Initiator,
+                    Version = "FIX.4.2",
+                    Sender = "Client",
+                    Target = "Server",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:45.012",
+                    // The engine should sent a valid logon message first
+                    "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:45.012|49=Client|56=Server|108=5|98=0|141=Y|10=094|",
+                    "! 20170623-14:51:45.051",
+                    // The engine should accept the target's logon response
+                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Y|10=209|",
+                    // The engine should fail since we got a logon message while already successfully logged on
+                    "< 8=FIX.4.2|9=72|35=A|34=2|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Y|10=210|"
+                })
+                .Expect<EngineException>("Logon message received while already logged on")
+                .Run();
+        }
+
+        [TestMethod]
         public void succeeds_but_sends_a_resend_request_when_the_response_contains_a_sequence_number_that_is_too_high()
         {
             new Specification()

--- a/HotFix.Specification/logout/a_logout.cs
+++ b/HotFix.Specification/logout/a_logout.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using HotFix.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HotFix.Specification.logout
+{
+    [TestClass]
+    public class a_logout
+    {
+        [TestMethod]
+        public void that_is_not_initiated_sends_a_logout_response_and_disconnects()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Initiator,
+                    Version = "FIX.4.2",
+                    Sender = "Client",
+                    Target = "Server",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:45.012",
+                    "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:45.012|49=Client|56=Server|108=5|98=0|141=Y|10=094|",
+                    "! 20170623-14:51:45.051",
+                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Y|10=209|",
+                    "! 20170623-14:51:46.000",
+                    // The engine receives a logout message
+                    "< 8=FIX.4.2|9=55|35=5|34=2|49=Server|52=20170623-14:51:46.000|56=Client|10=170|",
+                    // The engine responds back with a logout message
+                    "> 8=FIX.4.2|9=00055|35=5|34=2|52=20170623-14:51:46.000|49=Client|56=Server|10=058|"
+                })
+                .Verify((session, configuration, transport) =>
+                {
+                    session.State.InboundSeqNum.Should().Be(3);
+                    session.State.OutboundSeqNum.Should().Be(3);
+                    session.Active.Should().Be(false);
+                    transport.Disposed.Should().Be(true);
+                })
+                .Run();
+        }
+
+        [TestMethod]
+        public void that_is_initiated_sends_a_logout_response_and_disconnects()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Initiator,
+                    Version = "FIX.4.2",
+                    Sender = "Client",
+                    Target = "Server",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:45.012",
+                    "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:45.012|49=Client|56=Server|108=5|98=0|141=Y|10=094|",
+                    "! 20170623-14:51:45.051",
+                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Y|10=209|",
+                    "! 20170623-14:51:46.000",
+                    // The user decides to stop the session
+                    "X",
+                    // The engine sends a logout message
+                    "> 8=FIX.4.2|9=00055|35=5|34=2|52=20170623-14:51:46.000|49=Client|56=Server|10=058|"
+                })
+                .Verify((session, configuration, transport) =>
+                {
+                    session.State.InboundSeqNum.Should().Be(2);
+                    session.State.OutboundSeqNum.Should().Be(3);
+                    session.Active.Should().Be(false);
+                    transport.Disposed.Should().Be(true);
+                })
+                .Run();
+        }
+    }
+}

--- a/HotFix.Specification/logout/an_initiated_logout.cs
+++ b/HotFix.Specification/logout/an_initiated_logout.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using HotFix.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HotFix.Specification.logout
+{
+    [TestClass]
+    public class an_initiated_logout
+    {
+        [TestMethod]
+        public void sends_a_logout_message_and_disconnects()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Initiator,
+                    Version = "FIX.4.2",
+                    Sender = "Client",
+                    Target = "Server",
+                    HeartbeatInterval = 5,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:45.012",
+                    "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:45.012|49=Client|56=Server|108=5|98=0|141=Y|10=094|",
+                    "! 20170623-14:51:45.051",
+                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Y|10=209|",
+                    "! 20170623-14:51:46.000",
+                    // The user decides to stop the session
+                    "X",
+                    // The engine sends a logout message
+                    "> 8=FIX.4.2|9=00055|35=5|34=2|52=20170623-14:51:46.000|49=Client|56=Server|10=058|"
+                })
+                .Verify((session, configuration, transport) =>
+                {
+                    session.State.InboundSeqNum.Should().Be(2);
+                    session.State.OutboundSeqNum.Should().Be(3);
+                    session.Active.Should().Be(false);
+                    transport.Disposed.Should().Be(true);
+                })
+                .Run();
+        }
+    }
+}

--- a/HotFix.Specification/logout/an_uninitiated_logout.cs
+++ b/HotFix.Specification/logout/an_uninitiated_logout.cs
@@ -7,10 +7,10 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace HotFix.Specification.logout
 {
     [TestClass]
-    public class a_logout
+    public class an_uninitiated_logout
     {
         [TestMethod]
-        public void that_is_not_initiated_sends_a_logout_response_and_disconnects()
+        public void sends_a_logout_response_and_disconnects()
         {
             new Specification()
                 .Configure(new Configuration
@@ -38,42 +38,6 @@ namespace HotFix.Specification.logout
                 .Verify((session, configuration, transport) =>
                 {
                     session.State.InboundSeqNum.Should().Be(3);
-                    session.State.OutboundSeqNum.Should().Be(3);
-                    session.Active.Should().Be(false);
-                    transport.Disposed.Should().Be(true);
-                })
-                .Run();
-        }
-
-        [TestMethod]
-        public void that_is_initiated_sends_a_logout_response_and_disconnects()
-        {
-            new Specification()
-                .Configure(new Configuration
-                {
-                    Role = Role.Initiator,
-                    Version = "FIX.4.2",
-                    Sender = "Client",
-                    Target = "Server",
-                    HeartbeatInterval = 5,
-                    OutboundSeqNum = 1,
-                    InboundSeqNum = 1
-                })
-                .Steps(new List<string>
-                {
-                    "! 20170623-14:51:45.012",
-                    "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:45.012|49=Client|56=Server|108=5|98=0|141=Y|10=094|",
-                    "! 20170623-14:51:45.051",
-                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=5|98=0|141=Y|10=209|",
-                    "! 20170623-14:51:46.000",
-                    // The user decides to stop the session
-                    "X",
-                    // The engine sends a logout message
-                    "> 8=FIX.4.2|9=00055|35=5|34=2|52=20170623-14:51:46.000|49=Client|56=Server|10=058|"
-                })
-                .Verify((session, configuration, transport) =>
-                {
-                    session.State.InboundSeqNum.Should().Be(2);
                     session.State.OutboundSeqNum.Should().Be(3);
                     session.Active.Should().Be(false);
                     transport.Disposed.Should().Be(true);

--- a/HotFix.Specification/resend_request/an_inbound_resend_request.cs
+++ b/HotFix.Specification/resend_request/an_inbound_resend_request.cs
@@ -63,10 +63,10 @@ namespace HotFix.Specification.resend_request
                     "> 8=FIX.4.2|9=00067|35=4|34=5|52=20170623-14:51:47.000|49=Client|56=Server|123=Y|36=11|10=118|",
                     "! 20170623-14:51:51.000"
                 })
-                .Verify((engine, configuration) =>
+                .Verify((session, configuration, _) =>
                 {
-                    engine.State.InboundSeqNum.Should().Be(12L);
-                    engine.State.OutboundSeqNum.Should().Be(11L);
+                    session.State.InboundSeqNum.Should().Be(12L);
+                    session.State.OutboundSeqNum.Should().Be(11L);
                 })
                 .Run();
         }

--- a/HotFix.Specification/test_request/an_inbound_test_request.cs
+++ b/HotFix.Specification/test_request/an_inbound_test_request.cs
@@ -37,10 +37,10 @@ namespace HotFix.Specification.test_request
                     "> 8=FIX.4.2|9=00065|35=0|34=2|52=20170623-14:51:47.000|49=Client|56=Server|112=XXXXX|10=193|",
                     "! 20170623-14:51:48.000"
                 })
-                .Verify((engine, configuration) =>
+                .Verify((session, configuration, _) =>
                 {
-                    engine.State.InboundSeqNum.Should().Be(3);
-                    engine.State.OutboundSeqNum.Should().Be(3);
+                    session.State.InboundSeqNum.Should().Be(3);
+                    session.State.OutboundSeqNum.Should().Be(3);
                 })
                 .Run();
         }

--- a/HotFix.Specification/test_request/an_outbound_test_request.cs
+++ b/HotFix.Specification/test_request/an_outbound_test_request.cs
@@ -41,10 +41,10 @@ namespace HotFix.Specification.test_request
                     // The engine should send a test request since no inbound messages have been received
                     "> 8=FIX.4.2|9=00078|35=1|34=3|52=20170623-14:51:52.000|49=Client|56=Server|112=636338263120000000|10=150|"
                 })
-                .Verify((engine, configuration) =>
+                .Verify((session, configuration, _) =>
                 {
-                    engine.State.InboundSeqNum.Should().Be(2);
-                    engine.State.OutboundSeqNum.Should().Be(4);
+                    session.State.InboundSeqNum.Should().Be(2);
+                    session.State.OutboundSeqNum.Should().Be(4);
                 })
                 .Run();
         }
@@ -137,10 +137,10 @@ namespace HotFix.Specification.test_request
                     "! 20170623-14:52:05.000",
                     "! 20170623-14:52:06.000"
                 })
-                .Verify((engine, configuration) =>
+                .Verify((session, configuration, _) =>
                 {
-                    engine.State.InboundSeqNum.Should().Be(5);
-                    engine.State.OutboundSeqNum.Should().Be(6);
+                    session.State.InboundSeqNum.Should().Be(5);
+                    session.State.OutboundSeqNum.Should().Be(6);
                 })
                 .Run();
         }

--- a/HotFix/Core/Session.cs
+++ b/HotFix/Core/Session.cs
@@ -53,6 +53,8 @@ namespace HotFix.Core
 
         public void Logout()
         {
+            if (!Active) return;
+
             // Prepare and send a logout message
             Outbound.Prepare("5");
             Outbound.Set(34, State.OutboundSeqNum);
@@ -128,8 +130,6 @@ namespace HotFix.Core
 
             return inbound.Valid;
         }
-
-        
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SendHeartbeat(IConfiguration configuration, State state, Channel channel, FIXMessageWriter outbound)
@@ -227,7 +227,7 @@ namespace HotFix.Core
 
         public void HandleLogout(IConfiguration configuration, State state, Channel channel, FIXMessage inbound, FIXMessageWriter outbound)
         {
-            Active = false;
+            Logout();
         }
 
         public void HandleLogon(IConfiguration configuration, State state, Channel channel, FIXMessage inbound, FIXMessageWriter outbound)

--- a/HotFix/Core/Session.cs
+++ b/HotFix/Core/Session.cs
@@ -81,6 +81,7 @@ namespace HotFix.Core
                     if (inbound[35].Is("1")) HandleTestRequest(configuration, state, channel, inbound, outbound);
                     if (inbound[35].Is("2")) HandleResendRequest(configuration, state, channel, inbound, outbound);
                     if (inbound[35].Is("4")) HandleSequenceReset(configuration, state, channel, inbound, outbound);
+                    if (inbound[35].Is("A")) throw new EngineException("Logon message received while already logged on");
 
                     state.InboundSeqNum++;
                     state.InboundTimestamp = clock.Time;


### PR DESCRIPTION
- Engine fails when receiving a logon message while already logged on
- Added rudimentary support for Logout
  - Added Logout method that should be called after receive loop is finished
  - Transport is disposed when the session is disposed (should be called after logging out)
  - Session carries a Active flag set by incoming logout requests
  - Virtual transport now understands the "X" command, signifying the user's intent to quit