### PR TITLE
Feature/demo

### DIFF
--- a/HotFix.Demo.Acceptor/App.config
+++ b/HotFix.Demo.Acceptor/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/HotFix.Demo.Acceptor/HotFix.Demo.Acceptor.csproj
+++ b/HotFix.Demo.Acceptor/HotFix.Demo.Acceptor.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1B14CE3D-3274-48AD-94B7-B0925ED900D1}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>HotFix.Demo.Acceptor</RootNamespace>
+    <AssemblyName>HotFix.Demo.Acceptor</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HotFix\HotFix.csproj">
+      <Project>{4fc75a1e-ea9c-4512-a41e-650f00f21fb3}</Project>
+      <Name>HotFix</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/HotFix.Demo.Acceptor/Program.cs
+++ b/HotFix.Demo.Acceptor/Program.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using HotFix.Core;
+
+namespace HotFix.Demo.Acceptor
+{
+    class Program
+    {
+        private static int _orders;
+        private static int _executions;
+
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Waiting for orders...");
+
+            var engine = new Engine();
+
+            var configuration = new Configuration
+            {
+                Role = Role.Acceptor,
+                Version = "FIX.4.2",
+                Host = "127.0.0.1",
+                Port = int.Parse(args[0]),
+                Sender = "Server",
+                Target = "Client",
+                InboundSeqNum = 1,
+                OutboundSeqNum = 1,
+                HeartbeatInterval = 86400
+            };
+
+            using (var session = engine.Open(configuration))
+            {
+                var clock = session.Clock;
+                var state = session.State;
+                var sender = session.Configuration.Sender;
+                var target = session.Configuration.Target;
+
+                var inbound = session.Inbound;
+                var outbound = session.Outbound;
+
+                session.Logon();
+
+                while (session.Active)
+                {
+                    session.Receive();
+
+                    if (!inbound.Valid || !inbound[35].Is("D")) continue;
+
+                    outbound.Prepare("8");
+
+                    outbound.Set(34, state.OutboundSeqNum);
+                    outbound.Set(52, clock.Time);
+                    outbound.Set(49, sender);
+                    outbound.Set(56, target);
+
+                    outbound.Set(37, ++_orders);     // OrderId 
+                    outbound.Set(11, ++_executions); // ExecId 
+                    outbound.Set(20, 0);             // ExecTransType (New) 
+                    outbound.Set(150, 2);            // ExecType (Fill) 
+                    outbound.Set(39, 2);             // OrdStatus (Filled) 
+
+                    outbound.Set(11, inbound[11]);   // ClOrdId 
+                    outbound.Set(55, inbound[55]);   // Symbol 
+                    outbound.Set(54, inbound[54]);   // Side 
+                    outbound.Set(38, inbound[38]);   // OrderQty 
+                    outbound.Set(44, inbound[44]);   // Price 
+                    outbound.Set(6,  inbound[44]);   // AvgPrice 
+                    outbound.Set(14, inbound[38]);   // CumQty 
+                    outbound.Set(151, 0);            // LeavesQty 
+
+                    outbound.Build();
+
+                    session.Send(state, session.Channel, outbound);
+                }
+
+                session.Logout();
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("Orders: " + _orders);
+            Console.WriteLine("Filled: " + _executions);
+        }
+    }
+}

--- a/HotFix.Demo.Acceptor/Properties/AssemblyInfo.cs
+++ b/HotFix.Demo.Acceptor/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("HotFix.Demo.Acceptor")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("HotFix.Demo.Acceptor")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("1b14ce3d-3274-48ad-94b7-b0925ed900d1")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/HotFix.Demo.Initiator/App.config
+++ b/HotFix.Demo.Initiator/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/HotFix.Demo.Initiator/HotFix.Demo.Initiator.csproj
+++ b/HotFix.Demo.Initiator/HotFix.Demo.Initiator.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6DDBCECF-3B57-4CAD-BAD2-93CC1D71911E}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>HotFix.Demo.Initiator</RootNamespace>
+    <AssemblyName>HotFix.Demo.Initiator</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HotFix\HotFix.csproj">
+      <Project>{4fc75a1e-ea9c-4512-a41e-650f00f21fb3}</Project>
+      <Name>HotFix</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/HotFix.Demo.Initiator/Program.cs
+++ b/HotFix.Demo.Initiator/Program.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using HotFix.Core;
+
+namespace HotFix.Demo.Initiator
+{
+    class Program
+    {
+        private static int _orders;
+
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Sending orders...");
+
+            var count = int.Parse(args[2]);
+            var histogram = new List<long>(count * 2);
+
+            var engine = new Engine();
+
+            var configuration = new Configuration
+            {
+                Role = Role.Initiator,
+                Version = "FIX.4.2",
+                Host = args[0],
+                Port = int.Parse(args[1]),
+                Sender = "Client",
+                Target = "Server",
+                InboundSeqNum = 1,
+                OutboundSeqNum = 1,
+                HeartbeatInterval = 86400
+            };
+
+            using (var session = engine.Open(configuration))
+            {
+                var clock = session.Clock;
+                var state = session.State;
+                var sender = session.Configuration.Sender;
+                var target = session.Configuration.Target;
+
+                var inbound = session.Inbound;
+                var outbound = session.Outbound;
+
+                session.Logon();
+
+                while (session.Active && _orders < count)
+                {
+                    var sent = clock.Time;
+
+                    outbound.Prepare("D");
+
+                    outbound.Set(34, state.OutboundSeqNum);
+                    outbound.Set(52, clock.Time);
+                    outbound.Set(49, sender);
+                    outbound.Set(56, target);
+
+                    outbound.Set(60, clock.Time);         // TransactTime 
+                    outbound.Set(11, ++_orders);          // ClOrdId 
+                    outbound.Set(55, "EUR/USD");          // Symbol 
+                    outbound.Set(54, 1);                  // Side (buy) 
+                    outbound.Set(38, 1000.00);            // OrderQty 
+                    outbound.Set(44, 1.13200);            // Price 
+                    outbound.Set(40, 2);                  // OrdType (limit) 
+
+                    outbound.Build();
+
+                    session.Send(state, session.Channel, outbound);
+
+
+                    while (!session.Receive()) { }
+
+                    if (inbound[35].Is("8"))
+                    {
+                        var received = clock.Time;
+
+                        histogram.Add(received.Ticks - sent.Ticks);
+                    }
+                }
+
+                session.Logout();
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("Orders: " + _orders);
+
+            histogram = histogram.Skip(1000).Select(x => x).ToList();
+
+            Console.WriteLine($"   50.00%: {$"{Percentile(histogram, 0.5000) / 10m:N}",14} µs");
+            Console.WriteLine($"   90.00%: {$"{Percentile(histogram, 0.9000) / 10m:N}",14} µs");
+            Console.WriteLine($"   99.00%: {$"{Percentile(histogram, 0.9900) / 10m:N}",14} µs");
+            Console.WriteLine($"   99.90%: {$"{Percentile(histogram, 0.9990) / 10m:N}",14} µs");
+            Console.WriteLine($"   99.99%: {$"{Percentile(histogram, 0.9999) / 10m:N}",14} µs");
+            Console.WriteLine($"  100.00%: {$"{Percentile(histogram, 1.0000) / 10m:N}",14} µs");
+
+        }
+
+        public static long Percentile(List<long> sequence, double excelPercentile)
+        {
+            var sorted = sequence.OrderBy(x => x).ToList();
+
+            var N = sorted.Count;
+            var n = (N - 1) * excelPercentile + 1;
+
+            if (n == 1d) return sorted[0];
+            if (n == N) return sorted[N - 1];
+
+            var k = (int)n;
+            var d = n - k;
+
+            return (long)(sorted[k - 1] + d * (sorted[k] - sorted[k - 1]));
+        }
+    }
+}

--- a/HotFix.Demo.Initiator/Properties/AssemblyInfo.cs
+++ b/HotFix.Demo.Initiator/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("HotFix.Demo.Initiator")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("HotFix.Demo.Initiator")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6ddbcecf-3b57-4cad-bad2-93cc1d71911e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/HotFix.sln
+++ b/HotFix.sln
@@ -17,6 +17,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".common", ".common", "{D0FC
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HotFix.Demo.Acceptor", "HotFix.Demo.Acceptor\HotFix.Demo.Acceptor.csproj", "{1B14CE3D-3274-48AD-94B7-B0925ED900D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HotFix.Demo.Initiator", "HotFix.Demo.Initiator\HotFix.Demo.Initiator.csproj", "{6DDBCECF-3B57-4CAD-BAD2-93CC1D71911E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +43,14 @@ Global
 		{A364023B-5F1C-4F61-A329-A8E33F6582B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A364023B-5F1C-4F61-A329-A8E33F6582B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A364023B-5F1C-4F61-A329-A8E33F6582B4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B14CE3D-3274-48AD-94B7-B0925ED900D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B14CE3D-3274-48AD-94B7-B0925ED900D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B14CE3D-3274-48AD-94B7-B0925ED900D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B14CE3D-3274-48AD-94B7-B0925ED900D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6DDBCECF-3B57-4CAD-BAD2-93CC1D71911E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6DDBCECF-3B57-4CAD-BAD2-93CC1D71911E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6DDBCECF-3B57-4CAD-BAD2-93CC1D71911E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6DDBCECF-3B57-4CAD-BAD2-93CC1D71911E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/HotFix/Core/FIXField.cs
+++ b/HotFix/Core/FIXField.cs
@@ -5,8 +5,8 @@ namespace HotFix.Core
 {
     public struct FIXField
     {
-        private readonly byte[] _message;
-        private readonly Segment _value;
+        internal readonly byte[] _message;
+        internal readonly Segment _value;
 
         /// <summary> The tag of this field </summary>
         public int Tag { get; }

--- a/HotFix/Core/FIXMessageWriter.cs
+++ b/HotFix/Core/FIXMessageWriter.cs
@@ -87,6 +87,16 @@ namespace HotFix.Core
             _buffer[_end++] = SOH;
         }
 
+        public void Set(int tag, FIXField field)
+        {
+            _end += _buffer.WriteInt(_end, field.Tag);
+            _buffer[_end++] = EQL;
+
+            Buffer.BlockCopy(field._message, field._value.Offset, _buffer, _end, field._value.Length);
+            _end += field._value.Length;
+            _buffer[_end++] = SOH;
+        }
+
         public void Build()
         {
             _bodyEnd = _end - 1;


### PR DESCRIPTION
- Added demo acceptor and initiator (rtt)
- The demo is a realistic `round trip time` benchmark over **tcp**
    - Initiator sends a `new order - single` and waits for an `execution report`
    - Acceptor responds to any `new order - single` with a filled `execution report`
- Timings are taken in the initiator `before send` and `after receive` so provide an entire end-to-end
- Statistics are calculated over the entire dataset (_minus initial 1000 measurements to avoid jit overhead_) and show various percentiles

Sample output:
![image](https://user-images.githubusercontent.com/1388990/27872206-e94fd1c4-619f-11e7-8dd6-08dd432ed7d6.png)
