### PR TITLE
Feature/fluent message writing

### DIFF
--- a/HotFix.Benchmark/suites/writing_messages.cs
+++ b/HotFix.Benchmark/suites/writing_messages.cs
@@ -63,105 +63,17 @@ namespace HotFix.Benchmark.suites
             Message
                 .Clear()
                 .Set(262, "c6424b19-af74-4c17-8266-9c52ca583ad2")
-                .Set(268, 8);
-
-            Message
-                .Set(279, 2)
-                .Set(55, "GBP/JPY")
-                .Set(269, 0)
-                .Set(278, "1211918436")
-                .Set(270, 144.808000d)
-                .Set(271, 1000000d)
-                .Set(110, 0d)
-                .Set(15, "GBP")
-                .Set(282, 290);
-
-            Message
-                .Set(279, 2)
-                .Set(55, "GBP/JPY")
-                .Set(269, 0)
-                .Set(278, "1211918437")
-                .Set(270, 144.802000d)
-                .Set(271, 2000000d)
-                .Set(110, 0d)
-                .Set(15, "GBP")
-                .Set(282, 290);
-
-            Message
-                .Set(279, 0)
-                .Set(55, "GBP/JPY")
-                .Set(269, 0)
-                .Set(278, "1211918501")
-                .Set(270, 144.808000d)
-                .Set(271, 1000000d)
-                .Set(110, 0d)
-                .Set(15, "GBP")
-                .Set(282, 290)
-                .Set(735, 1)
-                .Set(695, 5);
-
-            Message
-                .Set(279, 0)
-                .Set(55, "GBP/JPY")
-                .Set(269, 0)
-                .Set(278, "1211918502")
-                .Set(270, 144.808000d)
-                .Set(271, 1000000d)
-                .Set(110, 0d)
-                .Set(15, "GBP")
-                .Set(282, 290)
-                .Set(735, 1)
-                .Set(695, 5);
-
-            Message
-                .Set(279, 2)
-                .Set(55, "GBP/JPY")
-                .Set(269, 0)
-                .Set(278, "1211918436")
-                .Set(270, 144.808000d)
-                .Set(271, 1000000d)
-                .Set(110, 0d)
-                .Set(15, "GBP")
-                .Set(282, 290);
-
-            Message
-                .Set(279, 2)
-                .Set(55, "GBP/JPY")
-                .Set(269, 0)
-                .Set(278, "1211918436")
-                .Set(270, 144.808000d)
-                .Set(271, 1000000d)
-                .Set(110, 0d)
-                .Set(15, "GBP")
-                .Set(282, 290);
-
-            Message
-                .Set(279, 2)
-                .Set(55, "GBP/JPY")
-                .Set(269, 0)
-                .Set(278, "1211918436")
-                .Set(270, 144.808000d)
-                .Set(271, 1000000d)
-                .Set(110, 0d)
-                .Set(15, "GBP")
-                .Set(282, 290)
-                .Set(735, 1)
-                .Set(695, 5);
-
-            Message
-                .Set(279, 2)
-                .Set(55, "GBP/JPY")
-                .Set(269, 0)
-                .Set(278, "1211918436")
-                .Set(270, 144.808000d)
-                .Set(271, 1000000d)
-                .Set(110, 0d)
-                .Set(15, "GBP")
-                .Set(282, 290)
-                .Set(735, 1)
-                .Set(695, 5);
-
-            Message.Prepare("FIX.4.2", "X", 8059, SendingTime, "SENDER....", "RECEIVER.....");
+                .Set(268, 8)
+                // Add quotes
+                .Set(279, 2).Set(55, "GBP/JPY").Set(269, 0).Set(278, "1211918436").Set(270, 144.808000d).Set(271, 1000000d).Set(110, 0d).Set(15, "GBP").Set(282, 290)
+                .Set(279, 2).Set(55, "GBP/JPY").Set(269, 0).Set(278, "1211918437").Set(270, 144.802000d).Set(271, 2000000d).Set(110, 0d).Set(15, "GBP").Set(282, 290)
+                .Set(279, 0).Set(55, "GBP/JPY").Set(269, 0).Set(278, "1211918501").Set(270, 144.808000d).Set(271, 1000000d).Set(110, 0d).Set(15, "GBP").Set(282, 290).Set(735, 1).Set(695, 5)
+                .Set(279, 0).Set(55, "GBP/JPY").Set(269, 0).Set(278, "1211918502").Set(270, 144.808000d).Set(271, 1000000d).Set(110, 0d).Set(15, "GBP").Set(282, 290).Set(735, 1).Set(695, 5)
+                .Set(279, 2).Set(55, "GBP/JPY").Set(269, 0).Set(278, "1211918436").Set(270, 144.808000d).Set(271, 1000000d).Set(110, 0d).Set(15, "GBP").Set(282, 290)
+                .Set(279, 2).Set(55, "GBP/JPY").Set(269, 0).Set(278, "1211918436").Set(270, 144.808000d).Set(271, 1000000d).Set(110, 0d).Set(15, "GBP").Set(282, 290)
+                .Set(279, 2).Set(55, "GBP/JPY").Set(269, 0).Set(278, "1211918436").Set(270, 144.808000d).Set(271, 1000000d).Set(110, 0d).Set(15, "GBP").Set(282, 290).Set(735, 1).Set(695, 5)
+                .Set(279, 2).Set(55, "GBP/JPY").Set(269, 0).Set(278, "1211918436").Set(270, 144.808000d).Set(271, 1000000d).Set(110, 0d).Set(15, "GBP").Set(282, 290).Set(735, 1).Set(695, 5)
+                .Prepare("FIX.4.2", "X", 8059, SendingTime, "SENDER....", "RECEIVER.....");
         }
     }
 }

--- a/HotFix.Benchmark/suites/writing_messages.cs
+++ b/HotFix.Benchmark/suites/writing_messages.cs
@@ -17,29 +17,21 @@ namespace HotFix.Benchmark.suites
         public readonly DateTime TransactTime = DateTime.ParseExact("2017/05/31 08:18:01.767", "yyyy/MM/dd", null);
         public readonly DateTime TradeDate = DateTime.ParseExact("2017/05/31", "yyyy/MM/dd", null);
 
-        public readonly FIXMessageWriter Message = new FIXMessageWriter(1000, "FIX.4.2");
+        public readonly FIXMessageWriter Message = new FIXMessageWriter(1000);
 
         [Benchmark]
         public void small()
         {
             Message
-                .Prepare("0")
-                .Set(34, 8059)
-                .Set(52, SendingTime)
-                .Set(49, "SENDER....")
-                .Set(56, "RECEIVER.....")
-                .Build();
+                .Clear()
+                .Prepare("FIX.4.2", "0", 8059, SendingTime, "SENDER....", "RECEIVER.....");
         }
 
         [Benchmark]
         public void medium()
         {
             Message
-                .Prepare("8")
-                .Set(34, 8059)
-                .Set(52, SendingTime)
-                .Set(49, "SENDER....")
-                .Set(56, "RECEIVER.....")
+                .Clear()
                 .Set(20, 0)
                 .Set(39, 2)
                 .Set(150, 2)
@@ -62,18 +54,14 @@ namespace HotFix.Benchmark.suites
                 .Set(37, "0804188884")
                 .Set(15, "EUR")
                 .Set(44, 1.504200d)
-                .Build();
+                .Prepare("FIX.4.2", "8", 8059, SendingTime, "SENDER....", "RECEIVER.....");
         }
 
         [Benchmark]
         public void large()
         {
             Message
-                .Prepare("0")
-                .Set(34, 8059)
-                .Set(52, SendingTime)
-                .Set(49, "SENDER....")
-                .Set(56, "RECEIVER.....")
+                .Clear()
                 .Set(262, "c6424b19-af74-4c17-8266-9c52ca583ad2")
                 .Set(268, 8);
 
@@ -168,7 +156,7 @@ namespace HotFix.Benchmark.suites
                 .Set(735, 1)
                 .Set(695, 5);
 
-            Message.Build();
+            Message.Prepare("FIX.4.2", "X", 8059, SendingTime, "SENDER....", "RECEIVER.....");
         }
     }
 }

--- a/HotFix.Benchmark/suites/writing_messages.cs
+++ b/HotFix.Benchmark/suites/writing_messages.cs
@@ -22,147 +22,151 @@ namespace HotFix.Benchmark.suites
         [Benchmark]
         public void small()
         {
-            Message.Prepare("0");
-            Message.Set(34, 8059);
-            Message.Set(52, SendingTime);
-            Message.Set(49, "SENDER....");
-            Message.Set(56, "RECEIVER.....");
-
-            Message.Build();
+            Message
+                .Prepare("0")
+                .Set(34, 8059)
+                .Set(52, SendingTime)
+                .Set(49, "SENDER....")
+                .Set(56, "RECEIVER.....")
+                .Build();
         }
 
         [Benchmark]
         public void medium()
         {
-            Message.Prepare("8");
-            Message.Set(34, 8059);
-            Message.Set(52, SendingTime);
-            Message.Set(49, "SENDER....");
-            Message.Set(56, "RECEIVER.....");
-            Message.Set(20, 0);
-            Message.Set(39, 2);
-            Message.Set(150, 2);
-            Message.Set(17, "U201:053117:00000079:B");
-            Message.Set(40, 2);
-            Message.Set(55, "EUR/CAD");
-            Message.Set(54, 1);
-            Message.Set(38, 900000d);
-            Message.Set(151, 0);
-            Message.Set(14, 900000d);
-            Message.Set(32, 100000d);
-            Message.Set(32, 1.503850d);
-            Message.Set(6, 1.503940);
-            Message.Set(64, FutSettleDate); // should be in YYYYMMDD format
-            Message.Set(60, TransactTime);
-            Message.Set(75, TradeDate); // should be in YYYYMMDD format
-            Message.Set(9200, 'S');
-            Message.Set(9300, 647);
-            Message.Set(9500, 0d);
-            Message.Set(37, "0804188884");
-            Message.Set(15, "EUR");
-            Message.Set(44, 1.504200d);
-
-            Message.Build();
+            Message
+                .Prepare("8")
+                .Set(34, 8059)
+                .Set(52, SendingTime)
+                .Set(49, "SENDER....")
+                .Set(56, "RECEIVER.....")
+                .Set(20, 0)
+                .Set(39, 2)
+                .Set(150, 2)
+                .Set(17, "U201:053117:00000079:B")
+                .Set(40, 2)
+                .Set(55, "EUR/CAD")
+                .Set(54, 1)
+                .Set(38, 900000d)
+                .Set(151, 0)
+                .Set(14, 900000d)
+                .Set(32, 100000d)
+                .Set(32, 1.503850d)
+                .Set(6, 1.503940)
+                .Set(64, FutSettleDate) // should be in YYYYMMDD format
+                .Set(60, TransactTime)
+                .Set(75, TradeDate) // should be in YYYYMMDD format
+                .Set(9200, 'S')
+                .Set(9300, 647)
+                .Set(9500, 0d)
+                .Set(37, "0804188884")
+                .Set(15, "EUR")
+                .Set(44, 1.504200d)
+                .Build();
         }
 
         [Benchmark]
         public void large()
         {
-            Message.Prepare("0");
-            Message.Set(34, 8059);
-            Message.Set(52, SendingTime);
-            Message.Set(49, "SENDER....");
-            Message.Set(56, "RECEIVER.....");
-            Message.Set(262, "c6424b19-af74-4c17-8266-9c52ca583ad2");
-            Message.Set(268, 8);
+            Message
+                .Prepare("0")
+                .Set(34, 8059)
+                .Set(52, SendingTime)
+                .Set(49, "SENDER....")
+                .Set(56, "RECEIVER.....")
+                .Set(262, "c6424b19-af74-4c17-8266-9c52ca583ad2")
+                .Set(268, 8);
 
-            Message.Set(279, 2);
-            Message.Set(55, "GBP/JPY");
-            Message.Set(269, 0);
-            Message.Set(278, "1211918436");
-            Message.Set(270, 144.808000d);
-            Message.Set(271, 1000000d);
-            Message.Set(110, 0d);
-            Message.Set(15, "GBP");
-            Message.Set(282, 290);
+            Message
+                .Set(279, 2)
+                .Set(55, "GBP/JPY")
+                .Set(269, 0)
+                .Set(278, "1211918436")
+                .Set(270, 144.808000d)
+                .Set(271, 1000000d)
+                .Set(110, 0d)
+                .Set(15, "GBP")
+                .Set(282, 290);
 
-            Message.Set(279, 2);
-            Message.Set(55, "GBP/JPY");
-            Message.Set(269, 0);
-            Message.Set(278, "1211918437");
-            Message.Set(270, 144.802000d);
-            Message.Set(271, 2000000d);
-            Message.Set(110, 0d);
-            Message.Set(15, "GBP");
-            Message.Set(282, 290);
+            Message
+                .Set(279, 2)
+                .Set(55, "GBP/JPY")
+                .Set(269, 0)
+                .Set(278, "1211918437")
+                .Set(270, 144.802000d)
+                .Set(271, 2000000d)
+                .Set(110, 0d)
+                .Set(15, "GBP")
+                .Set(282, 290);
 
-            Message.Set(279, 0);
-            Message.Set(55, "GBP/JPY");
-            Message.Set(269, 0);
-            Message.Set(278, "1211918501");
-            Message.Set(270, 144.808000d);
-            Message.Set(271, 1000000d);
-            Message.Set(110, 0d);
-            Message.Set(15, "GBP");
-            Message.Set(282, 290);
-            Message.Set(735, 1);
-            Message.Set(695, 5);
+            Message
+                .Set(279, 0)
+                .Set(55, "GBP/JPY")
+                .Set(269, 0)
+                .Set(278, "1211918501")
+                .Set(270, 144.808000d)
+                .Set(271, 1000000d)
+                .Set(110, 0d)
+                .Set(15, "GBP")
+                .Set(282, 290)
+                .Set(735, 1)
+                .Set(695, 5);
 
-            Message.Set(279, 0);
-            Message.Set(55, "GBP/JPY");
-            Message.Set(269, 0);
-            Message.Set(278, "1211918502");
-            Message.Set(270, 144.808000d);
-            Message.Set(271, 1000000d);
-            Message.Set(110, 0d);
-            Message.Set(15, "GBP");
-            Message.Set(282, 290);
-            Message.Set(735, 1);
-            Message.Set(695, 5);
+            Message.Set(279, 0)
+                .Set(55, "GBP/JPY")
+                .Set(269, 0)
+                .Set(278, "1211918502")
+                .Set(270, 144.808000d)
+                .Set(271, 1000000d)
+                .Set(110, 0d)
+                .Set(15, "GBP")
+                .Set(282, 290)
+                .Set(735, 1)
+                .Set(695, 5);
 
-            Message.Set(279, 2);
-            Message.Set(55, "GBP/JPY");
-            Message.Set(269, 0);
-            Message.Set(278, "1211918436");
-            Message.Set(270, 144.808000d);
-            Message.Set(271, 1000000d);
-            Message.Set(110, 0d);
-            Message.Set(15, "GBP");
-            Message.Set(282, 290);
+            Message.Set(279, 2)
+                .Set(55, "GBP/JPY")
+                .Set(269, 0)
+                .Set(278, "1211918436")
+                .Set(270, 144.808000d)
+                .Set(271, 1000000d)
+                .Set(110, 0d)
+                .Set(15, "GBP")
+                .Set(282, 290);
 
-            Message.Set(279, 2);
-            Message.Set(55, "GBP/JPY");
-            Message.Set(269, 0);
-            Message.Set(278, "1211918436");
-            Message.Set(270, 144.808000d);
-            Message.Set(271, 1000000d);
-            Message.Set(110, 0d);
-            Message.Set(15, "GBP");
-            Message.Set(282, 290);
+            Message.Set(279, 2)
+                .Set(55, "GBP/JPY")
+                .Set(269, 0)
+                .Set(278, "1211918436")
+                .Set(270, 144.808000d)
+                .Set(271, 1000000d)
+                .Set(110, 0d)
+                .Set(15, "GBP")
+                .Set(282, 290);
 
-            Message.Set(279, 2);
-            Message.Set(55, "GBP/JPY");
-            Message.Set(269, 0);
-            Message.Set(278, "1211918436");
-            Message.Set(270, 144.808000d);
-            Message.Set(271, 1000000d);
-            Message.Set(110, 0d);
-            Message.Set(15, "GBP");
-            Message.Set(282, 290);
-            Message.Set(735, 1);
-            Message.Set(695, 5);
+            Message.Set(279, 2)
+                .Set(55, "GBP/JPY")
+                .Set(269, 0)
+                .Set(278, "1211918436")
+                .Set(270, 144.808000d)
+                .Set(271, 1000000d)
+                .Set(110, 0d)
+                .Set(15, "GBP")
+                .Set(282, 290)
+                .Set(735, 1)
+                .Set(695, 5);
 
-            Message.Set(279, 2);
-            Message.Set(55, "GBP/JPY");
-            Message.Set(269, 0);
-            Message.Set(278, "1211918436");
-            Message.Set(270, 144.808000d);
-            Message.Set(271, 1000000d);
-            Message.Set(110, 0d);
-            Message.Set(15, "GBP");
-            Message.Set(282, 290);
-            Message.Set(735, 1);
-            Message.Set(695, 5);
+            Message.Set(279, 2)
+                .Set(55, "GBP/JPY")
+                .Set(269, 0)
+                .Set(278, "1211918436")
+                .Set(270, 144.808000d)
+                .Set(271, 1000000d)
+                .Set(110, 0d)
+                .Set(15, "GBP")
+                .Set(282, 290)
+                .Set(735, 1)
+                .Set(695, 5);
 
             Message.Build();
         }

--- a/HotFix.Benchmark/suites/writing_messages.cs
+++ b/HotFix.Benchmark/suites/writing_messages.cs
@@ -100,7 +100,8 @@ namespace HotFix.Benchmark.suites
                 .Set(735, 1)
                 .Set(695, 5);
 
-            Message.Set(279, 0)
+            Message
+                .Set(279, 0)
                 .Set(55, "GBP/JPY")
                 .Set(269, 0)
                 .Set(278, "1211918502")
@@ -112,7 +113,8 @@ namespace HotFix.Benchmark.suites
                 .Set(735, 1)
                 .Set(695, 5);
 
-            Message.Set(279, 2)
+            Message
+                .Set(279, 2)
                 .Set(55, "GBP/JPY")
                 .Set(269, 0)
                 .Set(278, "1211918436")
@@ -122,7 +124,8 @@ namespace HotFix.Benchmark.suites
                 .Set(15, "GBP")
                 .Set(282, 290);
 
-            Message.Set(279, 2)
+            Message
+                .Set(279, 2)
                 .Set(55, "GBP/JPY")
                 .Set(269, 0)
                 .Set(278, "1211918436")
@@ -132,7 +135,8 @@ namespace HotFix.Benchmark.suites
                 .Set(15, "GBP")
                 .Set(282, 290);
 
-            Message.Set(279, 2)
+            Message
+                .Set(279, 2)
                 .Set(55, "GBP/JPY")
                 .Set(269, 0)
                 .Set(278, "1211918436")
@@ -144,7 +148,8 @@ namespace HotFix.Benchmark.suites
                 .Set(735, 1)
                 .Set(695, 5);
 
-            Message.Set(279, 2)
+            Message
+                .Set(279, 2)
                 .Set(55, "GBP/JPY")
                 .Set(269, 0)
                 .Set(278, "1211918436")

--- a/HotFix.Demo.Acceptor/Program.cs
+++ b/HotFix.Demo.Acceptor/Program.cs
@@ -29,10 +29,7 @@ namespace HotFix.Demo.Acceptor
 
             using (var session = engine.Open(configuration))
             {
-                var clock = session.Clock;
                 var state = session.State;
-                var sender = session.Configuration.Sender;
-                var target = session.Configuration.Target;
 
                 var inbound = session.Inbound;
                 var outbound = session.Outbound;
@@ -45,31 +42,23 @@ namespace HotFix.Demo.Acceptor
 
                     if (!inbound.Valid || !inbound[35].Is("D")) continue;
 
-                    outbound.Prepare("8");
+                    outbound
+                        .Clear()
+                        .Set(37, ++_orders)     // OrderId 
+                        .Set(11, ++_executions) // ExecId 
+                        .Set(20, 0)             // ExecTransType (New) 
+                        .Set(150, 2)            // ExecType (Fill) 
+                        .Set(39, 2)             // OrdStatus (Filled) 
+                        .Set(11, inbound[11])   // ClOrdId 
+                        .Set(55, inbound[55])   // Symbol 
+                        .Set(54, inbound[54])   // Side 
+                        .Set(38, inbound[38])   // OrderQty 
+                        .Set(44, inbound[44])   // Price 
+                        .Set(6,  inbound[44])   // AvgPrice 
+                        .Set(14, inbound[38])   // CumQty 
+                        .Set(151, 0);            // LeavesQty 
 
-                    outbound.Set(34, state.OutboundSeqNum);
-                    outbound.Set(52, clock.Time);
-                    outbound.Set(49, sender);
-                    outbound.Set(56, target);
-
-                    outbound.Set(37, ++_orders);     // OrderId 
-                    outbound.Set(11, ++_executions); // ExecId 
-                    outbound.Set(20, 0);             // ExecTransType (New) 
-                    outbound.Set(150, 2);            // ExecType (Fill) 
-                    outbound.Set(39, 2);             // OrdStatus (Filled) 
-
-                    outbound.Set(11, inbound[11]);   // ClOrdId 
-                    outbound.Set(55, inbound[55]);   // Symbol 
-                    outbound.Set(54, inbound[54]);   // Side 
-                    outbound.Set(38, inbound[38]);   // OrderQty 
-                    outbound.Set(44, inbound[44]);   // Price 
-                    outbound.Set(6,  inbound[44]);   // AvgPrice 
-                    outbound.Set(14, inbound[38]);   // CumQty 
-                    outbound.Set(151, 0);            // LeavesQty 
-
-                    outbound.Build();
-
-                    session.Send(state, session.Channel, outbound);
+                    session.Send("8", state, session.Channel, outbound);
                 }
 
                 session.Logout();

--- a/HotFix.Demo.Acceptor/Program.cs
+++ b/HotFix.Demo.Acceptor/Program.cs
@@ -56,7 +56,7 @@ namespace HotFix.Demo.Acceptor
                         .Set(44, inbound[44])   // Price 
                         .Set(6,  inbound[44])   // AvgPrice 
                         .Set(14, inbound[38])   // CumQty 
-                        .Set(151, 0);            // LeavesQty 
+                        .Set(151, 0);           // LeavesQty 
 
                     session.Send("8", state, session.Channel, outbound);
                 }

--- a/HotFix.Demo.Initiator/Program.cs
+++ b/HotFix.Demo.Initiator/Program.cs
@@ -35,8 +35,6 @@ namespace HotFix.Demo.Initiator
             {
                 var clock = session.Clock;
                 var state = session.State;
-                var sender = session.Configuration.Sender;
-                var target = session.Configuration.Target;
 
                 var inbound = session.Inbound;
                 var outbound = session.Outbound;
@@ -47,25 +45,17 @@ namespace HotFix.Demo.Initiator
                 {
                     var sent = clock.Time;
 
-                    outbound.Prepare("D");
+                    outbound
+                        .Clear()
+                        .Set(60, clock.Time)         // TransactTime 
+                        .Set(11, ++_orders)          // ClOrdId 
+                        .Set(55, "EUR/USD")          // Symbol 
+                        .Set(54, 1)                  // Side (buy) 
+                        .Set(38, 1000.00)            // OrderQty 
+                        .Set(44, 1.13200)            // Price 
+                        .Set(40, 2);                  // OrdType (limit) 
 
-                    outbound.Set(34, state.OutboundSeqNum);
-                    outbound.Set(52, clock.Time);
-                    outbound.Set(49, sender);
-                    outbound.Set(56, target);
-
-                    outbound.Set(60, clock.Time);         // TransactTime 
-                    outbound.Set(11, ++_orders);          // ClOrdId 
-                    outbound.Set(55, "EUR/USD");          // Symbol 
-                    outbound.Set(54, 1);                  // Side (buy) 
-                    outbound.Set(38, 1000.00);            // OrderQty 
-                    outbound.Set(44, 1.13200);            // Price 
-                    outbound.Set(40, 2);                  // OrdType (limit) 
-
-                    outbound.Build();
-
-                    session.Send(state, session.Channel, outbound);
-
+                    session.Send("D", state, session.Channel, outbound);
 
                     while (!session.Receive()) { }
 

--- a/HotFix.Demo.Initiator/Program.cs
+++ b/HotFix.Demo.Initiator/Program.cs
@@ -53,7 +53,7 @@ namespace HotFix.Demo.Initiator
                         .Set(54, 1)                  // Side (buy) 
                         .Set(38, 1000.00)            // OrderQty 
                         .Set(44, 1.13200)            // Price 
-                        .Set(40, 2);                  // OrdType (limit) 
+                        .Set(40, 2);                 // OrdType (limit) 
 
                     session.Send("D", state, session.Channel, outbound);
 

--- a/HotFix.Test/core/messagewriter/building_a_message.cs
+++ b/HotFix.Test/core/messagewriter/building_a_message.cs
@@ -13,14 +13,15 @@ namespace HotFix.Test.core.messagewriter
         {
             var message = new FIXMessageWriter(1000, "FIX.4.2");
 
-            message.Prepare("A");
-            message.Set(49, "SERVER");
-            message.Set(56, "CLIENT");
-            message.Set(34, 177);
-            message.Set(52, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null));
-            message.Set(98, 0);
-            message.Set(108, 30);
-            message.Build();
+            message
+                .Prepare("A")
+                .Set(49, "SERVER")
+                .Set(56, "CLIENT")
+                .Set(34, 177)
+                .Set(52, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null))
+                .Set(98, 0)
+                .Set(108, 30)
+                .Build();
 
             var str = message.ToString();
 
@@ -33,25 +34,27 @@ namespace HotFix.Test.core.messagewriter
             var message = new FIXMessageWriter(1000, "FIX.4.2");
 
             // Prepare and build a small message
-            message.Prepare("0");
-            message.Set(34, 8059);
-            message.Set(52, DateTime.ParseExact("2017/05/31 08:18:01.767", "yyyy/MM/dd HH:mm:ss.fff", null));
-            message.Set(49, "SENDER....");
-            message.Set(56, "RECEIVER.....");
-            message.Build();
+            message
+                .Prepare("0")
+                .Set(34, 8059)
+                .Set(52, DateTime.ParseExact("2017/05/31 08:18:01.767", "yyyy/MM/dd HH:mm:ss.fff", null))
+                .Set(49, "SENDER....")
+                .Set(56, "RECEIVER.....")
+                .Build();
 
             var message1 = message.ToString();
 
             // Prepare and build a larger message
-            message.Prepare("A");
-            message.Set(49, "SERVER");
-            message.Set(56, "CLIENT");
-            message.Set(34, 177);
-            message.Set(52, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null));
-            message.Set(98, 0);
-            message.Set(108, 30);
-            message.Set(12345, "Some really long text to make the message really large sdkfjfkjs gfsabf sabf sahfvb ksdjflsahfpieghpEIGHXKJVB KLSGBS BHJUXVCJDV V JV jsdh fkasdgsadoas oghoash go iasg fcblxc nsleiso bnlzxcvn skjbg");
-            message.Build();
+            message
+                .Prepare("A")
+                .Set(49, "SERVER")
+                .Set(56, "CLIENT")
+                .Set(34, 177)
+                .Set(52, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null))
+                .Set(98, 0)
+                .Set(108, 30)
+                .Set(12345, "Some really long text to make the message really large sdkfjfkjs gfsabf sabf sahfvb ksdjflsahfpieghpEIGHXKJVB KLSGBS BHJUXVCJDV V JV jsdh fkasdgsadoas oghoash go iasg fcblxc nsleiso bnlzxcvn skjbg")
+                .Build();
 
             var message2 = message.ToString();
 
@@ -66,25 +69,27 @@ namespace HotFix.Test.core.messagewriter
             var message = new FIXMessageWriter(1000, "FIX.4.2");
 
             // Prepare and build a large message
-            message.Prepare("A");
-            message.Set(49, "SERVER");
-            message.Set(56, "CLIENT");
-            message.Set(34, 177);
-            message.Set(52, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null));
-            message.Set(98, 0);
-            message.Set(108, 30);
-            message.Set(12345, "Some really long text to make the message really large sdkfjfkjs gfsabf sabf sahfvb ksdjflsahfpieghpEIGHXKJVB KLSGBS BHJUXVCJDV V JV jsdh fkasdgsadoas oghoash go iasg fcblxc nsleiso bnlzxcvn skjbg");
-            message.Build();
+            message
+                .Prepare("A")
+                .Set(49, "SERVER")
+                .Set(56, "CLIENT")
+                .Set(34, 177)
+                .Set(52, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null))
+                .Set(98, 0)
+                .Set(108, 30)
+                .Set(12345, "Some really long text to make the message really large sdkfjfkjs gfsabf sabf sahfvb ksdjflsahfpieghpEIGHXKJVB KLSGBS BHJUXVCJDV V JV jsdh fkasdgsadoas oghoash go iasg fcblxc nsleiso bnlzxcvn skjbg")
+                .Build();
 
             var message1 = message.ToString();
 
             // Prepare and build a smaller message
-            message.Prepare("0");
-            message.Set(34, 8059);
-            message.Set(52, DateTime.ParseExact("2017/05/31 08:18:01.767", "yyyy/MM/dd HH:mm:ss.fff", null));
-            message.Set(49, "SENDER....");
-            message.Set(56, "RECEIVER.....");
-            message.Build();
+            message
+                .Prepare("0")
+                .Set(34, 8059)
+                .Set(52, DateTime.ParseExact("2017/05/31 08:18:01.767", "yyyy/MM/dd HH:mm:ss.fff", null))
+                .Set(49, "SENDER....")
+                .Set(56, "RECEIVER.....")
+                .Build();
 
             var message2 = message.ToString();
 

--- a/HotFix.Test/core/messagewriter/building_a_message.cs
+++ b/HotFix.Test/core/messagewriter/building_a_message.cs
@@ -11,90 +11,67 @@ namespace HotFix.Test.core.messagewriter
         [TestMethod]
         public void should_work()
         {
-            var message = new FIXMessageWriter(1000, "FIX.4.2");
+            var message = new FIXMessageWriter(1000);
 
             message
-                .Prepare("A")
-                .Set(49, "SERVER")
-                .Set(56, "CLIENT")
-                .Set(34, 177)
-                .Set(52, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null))
                 .Set(98, 0)
                 .Set(108, 30)
-                .Build();
+                .Prepare("FIX.4.2", "A", 177, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null), "SERVER", "CLIENT");
 
             var str = message.ToString();
 
-            str.Should().Be("8=FIX.4.2|9=00069|35=A|49=SERVER|56=CLIENT|34=177|52=20090107-18:15:16.000|98=0|108=30|10=144|".Replace("|", "\u0001"));
+            str.Should().Be("8=FIX.4.2|9=00069|35=A|34=177|52=20090107-18:15:16.000|49=SERVER|56=CLIENT|98=0|108=30|10=144|".Replace("|", "\u0001"));
         }
 
         [TestMethod]
         public void allows_the_message_to_be_reused_when_the_previous_message_was_smaller()
         {
-            var message = new FIXMessageWriter(1000, "FIX.4.2");
+            var message = new FIXMessageWriter(1000);
 
             // Prepare and build a small message
             message
-                .Prepare("0")
-                .Set(34, 8059)
-                .Set(52, DateTime.ParseExact("2017/05/31 08:18:01.767", "yyyy/MM/dd HH:mm:ss.fff", null))
-                .Set(49, "SENDER....")
-                .Set(56, "RECEIVER.....")
-                .Build();
+                .Prepare("FIX.4.2", "0", 8059, DateTime.ParseExact("2017/05/31 08:18:01.767", "yyyy/MM/dd HH:mm:ss.fff", null), "SENDER....", "RECEIVER.....");
 
             var message1 = message.ToString();
 
             // Prepare and build a larger message
             message
-                .Prepare("A")
-                .Set(49, "SERVER")
-                .Set(56, "CLIENT")
-                .Set(34, 177)
-                .Set(52, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null))
+                .Clear()
                 .Set(98, 0)
                 .Set(108, 30)
                 .Set(12345, "Some really long text to make the message really large sdkfjfkjs gfsabf sabf sahfvb ksdjflsahfpieghpEIGHXKJVB KLSGBS BHJUXVCJDV V JV jsdh fkasdgsadoas oghoash go iasg fcblxc nsleiso bnlzxcvn skjbg")
-                .Build();
+                .Prepare("FIX.4.2", "A", 177, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null), "SERVER", "CLIENT");
 
             var message2 = message.ToString();
 
             // NOTE: Message 1 has a smaller length
             message1.Should().Be("8=FIX.4.2|9=00069|35=0|34=8059|52=20170531-08:18:01.767|49=SENDER....|56=RECEIVER.....|10=203|".Replace("|", "\u0001"));
-            message2.Should().Be("8=FIX.4.2|9=00272|35=A|49=SERVER|56=CLIENT|34=177|52=20090107-18:15:16.000|98=0|108=30|12345=Some really long text to make the message really large sdkfjfkjs gfsabf sabf sahfvb ksdjflsahfpieghpEIGHXKJVB KLSGBS BHJUXVCJDV V JV jsdh fkasdgsadoas oghoash go iasg fcblxc nsleiso bnlzxcvn skjbg|10=026|".Replace("|", "\u0001"));
+            message2.Should().Be("8=FIX.4.2|9=00272|35=A|34=177|52=20090107-18:15:16.000|49=SERVER|56=CLIENT|98=0|108=30|12345=Some really long text to make the message really large sdkfjfkjs gfsabf sabf sahfvb ksdjflsahfpieghpEIGHXKJVB KLSGBS BHJUXVCJDV V JV jsdh fkasdgsadoas oghoash go iasg fcblxc nsleiso bnlzxcvn skjbg|10=026|".Replace("|", "\u0001"));
         }
 
         [TestMethod]
         public void allows_the_message_to_be_reused_when_the_previous_message_was_larger()
         {
-            var message = new FIXMessageWriter(1000, "FIX.4.2");
+            var message = new FIXMessageWriter(1000);
 
             // Prepare and build a large message
             message
-                .Prepare("A")
-                .Set(49, "SERVER")
-                .Set(56, "CLIENT")
-                .Set(34, 177)
-                .Set(52, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null))
                 .Set(98, 0)
                 .Set(108, 30)
                 .Set(12345, "Some really long text to make the message really large sdkfjfkjs gfsabf sabf sahfvb ksdjflsahfpieghpEIGHXKJVB KLSGBS BHJUXVCJDV V JV jsdh fkasdgsadoas oghoash go iasg fcblxc nsleiso bnlzxcvn skjbg")
-                .Build();
+                .Prepare("FIX.4.2", "A", 177, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null), "SERVER", "CLIENT");
 
             var message1 = message.ToString();
 
             // Prepare and build a smaller message
             message
-                .Prepare("0")
-                .Set(34, 8059)
-                .Set(52, DateTime.ParseExact("2017/05/31 08:18:01.767", "yyyy/MM/dd HH:mm:ss.fff", null))
-                .Set(49, "SENDER....")
-                .Set(56, "RECEIVER.....")
-                .Build();
+                .Clear()
+                .Prepare("FIX.4.2", "0", 8059, DateTime.ParseExact("2017/05/31 08:18:01.767", "yyyy/MM/dd HH:mm:ss.fff", null), "SENDER....", "RECEIVER.....");
 
             var message2 = message.ToString();
 
             // NOTE: Message 1 has a bigger length
-            message1.Should().Be("8=FIX.4.2|9=00272|35=A|49=SERVER|56=CLIENT|34=177|52=20090107-18:15:16.000|98=0|108=30|12345=Some really long text to make the message really large sdkfjfkjs gfsabf sabf sahfvb ksdjflsahfpieghpEIGHXKJVB KLSGBS BHJUXVCJDV V JV jsdh fkasdgsadoas oghoash go iasg fcblxc nsleiso bnlzxcvn skjbg|10=026|".Replace("|", "\u0001"));
+            message1.Should().Be("8=FIX.4.2|9=00272|35=A|34=177|52=20090107-18:15:16.000|49=SERVER|56=CLIENT|98=0|108=30|12345=Some really long text to make the message really large sdkfjfkjs gfsabf sabf sahfvb ksdjflsahfpieghpEIGHXKJVB KLSGBS BHJUXVCJDV V JV jsdh fkasdgsadoas oghoash go iasg fcblxc nsleiso bnlzxcvn skjbg|10=026|".Replace("|", "\u0001"));
             message2.Should().Be("8=FIX.4.2|9=00069|35=0|34=8059|52=20170531-08:18:01.767|49=SENDER....|56=RECEIVER.....|10=203|".Replace("|", "\u0001"));
         }
     }

--- a/HotFix/Core/Channel.cs
+++ b/HotFix/Core/Channel.cs
@@ -80,7 +80,7 @@ namespace HotFix.Core
         /// <param name="message"> The message to write </param>
         public void Write(FIXMessageWriter message)
         {
-            Transport.Write(message.Buffer, 0, message.End);
+            Transport.Write(message.Buffer, 0, message.Length);
         }
     }
 }

--- a/HotFix/Core/Channel.cs
+++ b/HotFix/Core/Channel.cs
@@ -80,7 +80,7 @@ namespace HotFix.Core
         /// <param name="message"> The message to write </param>
         public void Write(FIXMessageWriter message)
         {
-            Transport.Write(message._buffer, 0, message._end);
+            Transport.Write(message.Buffer, 0, message.End);
         }
     }
 }

--- a/HotFix/Core/FIXMessageWriter.cs
+++ b/HotFix/Core/FIXMessageWriter.cs
@@ -34,60 +34,72 @@ namespace HotFix.Core
             _end += _buffer.WriteString(_end, "35=");
         }
 
-        public void Prepare(string messageType)
+        public FIXMessageWriter Prepare(string messageType)
         {
             _end = _headerEnd + 4;
 
             _end += _buffer.WriteString(_end, messageType);
             _buffer[_end++] = SOH;
+
+            return this;
         }
 
-        public void Set(int tag, string value)
+        public FIXMessageWriter Set(int tag, string value)
         {
             _end += _buffer.WriteInt(_end, tag);
             _buffer[_end++] = EQL;
 
             _end += _buffer.WriteString(_end, value);
             _buffer[_end++] = SOH;
+
+            return this;
         }
 
-        public void Set(int tag, int value)
+        public FIXMessageWriter Set(int tag, int value)
         {
             _end += _buffer.WriteInt(_end, tag);
             _buffer[_end++] = EQL;
 
             _end += _buffer.WriteInt(_end, value);
             _buffer[_end++] = SOH;
+
+            return this;
         }
 
-        public void Set(int tag, DateTime value)
+        public FIXMessageWriter Set(int tag, DateTime value)
         {
             _end += _buffer.WriteInt(_end, tag);
             _buffer[_end++] = EQL;
 
             _end += _buffer.WriteDateTime(_end, value);
             _buffer[_end++] = SOH;
+
+            return this;
         }
 
-        public void Set(int tag, long value)
+        public FIXMessageWriter Set(int tag, long value)
         {
             _end += _buffer.WriteInt(_end, tag);
             _buffer[_end++] = EQL;
 
             _end += _buffer.WriteLong(_end, value);
             _buffer[_end++] = SOH;
+
+            return this;
         }
 
-        public void Set(int tag, double value)
+        public FIXMessageWriter Set(int tag, double value)
         {
             _end += _buffer.WriteInt(_end, tag);
             _buffer[_end++] = EQL;
 
             _end += _buffer.WriteFloat(_end, value);
             _buffer[_end++] = SOH;
+
+            return this;
         }
 
-        public void Set(int tag, FIXField field)
+        public FIXMessageWriter Set(int tag, FIXField field)
         {
             _end += _buffer.WriteInt(_end, field.Tag);
             _buffer[_end++] = EQL;
@@ -95,9 +107,11 @@ namespace HotFix.Core
             Buffer.BlockCopy(field._message, field._value.Offset, _buffer, _end, field._value.Length);
             _end += field._value.Length;
             _buffer[_end++] = SOH;
+
+            return this;
         }
 
-        public void Build()
+        public FIXMessageWriter Build()
         {
             _bodyEnd = _end - 1;
 
@@ -111,6 +125,8 @@ namespace HotFix.Core
             _trailerEnd = _end;
 
             _buffer.WriteIntBackwards(_trailerEnd - 2, checksum);
+
+            return this;
         }
 
         private int CalculateChecksum()

--- a/HotFix/Core/FIXMessageWriter.cs
+++ b/HotFix/Core/FIXMessageWriter.cs
@@ -12,7 +12,7 @@ namespace HotFix.Core
         private int _bodyEnd;
 
         internal readonly byte[] Buffer;
-        internal int End;
+        internal int Length;
 
         public FIXMessageWriter(int maxLength)
         {
@@ -22,7 +22,7 @@ namespace HotFix.Core
 
         public FIXMessageWriter Clear()
         {
-            End = 0;
+            Length = 0;
             _bodyEnd = 0;
 
             return this;
@@ -30,54 +30,54 @@ namespace HotFix.Core
 
         public FIXMessageWriter Prepare(string beginString, string messageType, long seqNum, DateTime sendingTime, string sender, string target)
         {
-            // write beginstring
-            End = Buffer.WriteString(0, "8=");
-            End += Buffer.WriteString(End, beginString);
-            Buffer[End++] = SOH;
+            // Write beginstring
+            Length = Buffer.WriteString(0, "8=");
+            Length += Buffer.WriteString(Length, beginString);
+            Buffer[Length++] = SOH;
 
-            // write length placeholder
-            // Should probably measure how many digits are needed to represent maxLength and use that many zeros
-            // The zeros string could then be cached and reused since it can be calculated at construction time
-            End += Buffer.WriteString(End, "9=00000");
-            var lengthPosition = End - 1; // points to the last zero
-            Buffer[End++] = SOH;
+            // Write length placeholder
+            // TODO: Should probably measure how many digits are needed to represent maxLength and use that many zeros
+            //       The zeros string could then be cached and reused since it can be calculated at construction time
+            Length += Buffer.WriteString(Length, "9=00000");
+            var lengthPosition = Length - 1; // points to the last zero
+            Buffer[Length++] = SOH;
 
-            // write messagetype
-            End += Buffer.WriteString(End, "35=");
-            End += Buffer.WriteString(End, messageType);
-            Buffer[End++] = SOH;
+            // Write messagetype
+            Length += Buffer.WriteString(Length, "35=");
+            Length += Buffer.WriteString(Length, messageType);
+            Buffer[Length++] = SOH;
 
-            // write seqnum
-            End += Buffer.WriteString(End, "34=");
-            End += Buffer.WriteLong(End, seqNum);
-            Buffer[End++] = SOH;
+            // Write seqnum
+            Length += Buffer.WriteString(Length, "34=");
+            Length += Buffer.WriteLong(Length, seqNum);
+            Buffer[Length++] = SOH;
 
-            // write sendingTime
-            End += Buffer.WriteString(End, "52=");
-            End += Buffer.WriteDateTime(End, sendingTime);
-            Buffer[End++] = SOH;
+            // Write sendingTime
+            Length += Buffer.WriteString(Length, "52=");
+            Length += Buffer.WriteDateTime(Length, sendingTime);
+            Buffer[Length++] = SOH;
 
-            // write sender
-            End += Buffer.WriteString(End, "49=");
-            End += Buffer.WriteString(End, sender);
-            Buffer[End++] = SOH;
+            // Write sender
+            Length += Buffer.WriteString(Length, "49=");
+            Length += Buffer.WriteString(Length, sender);
+            Buffer[Length++] = SOH;
 
-            // write target
-            End += Buffer.WriteString(End, "56=");
-            End += Buffer.WriteString(End, target);
-            Buffer[End++] = SOH;
+            // Write target
+            Length += Buffer.WriteString(Length, "56=");
+            Length += Buffer.WriteString(Length, target);
+            Buffer[Length++] = SOH;
 
-            // copy body
-            System.Buffer.BlockCopy(_body, 0, Buffer, End, _bodyEnd);
-            End += _bodyEnd;
+            // Copy body
+            System.Buffer.BlockCopy(_body, 0, Buffer, Length, _bodyEnd);
+            Length += _bodyEnd;
 
-            // update length
-            Buffer.WriteIntBackwards(lengthPosition, End - (lengthPosition + 2));
+            // Update length
+            Buffer.WriteIntBackwards(lengthPosition, Length - (lengthPosition + 2));
 
-            // calculate and write checksum
+            // Calculate and write checksum
             var checksum = CalculateChecksum();
-            End += Buffer.WriteString(End, "10=000\u0001");
-            Buffer.WriteIntBackwards(End - 2, checksum);
+            Length += Buffer.WriteString(Length, "10=000\u0001");
+            Buffer.WriteIntBackwards(Length - 2, checksum);
 
             return this;
         }
@@ -153,7 +153,7 @@ namespace HotFix.Core
         {
             var checksum = 0;
 
-            for (var i = 0; i < End; i++)
+            for (var i = 0; i < Length; i++)
             {
                 checksum += Buffer[i];
             }
@@ -161,6 +161,6 @@ namespace HotFix.Core
             return checksum % 256;
         }
 
-        public override string ToString() => System.Text.Encoding.ASCII.GetString(Buffer, 0, End);
+        public override string ToString() => System.Text.Encoding.ASCII.GetString(Buffer, 0, Length);
     }
 }

--- a/HotFix/Core/Session.cs
+++ b/HotFix/Core/Session.cs
@@ -86,12 +86,13 @@ namespace HotFix.Core
             if (!Active) return;
 
             // Prepare and send a logout message
-            Outbound.Prepare("5");
-            Outbound.Set(34, State.OutboundSeqNum);
-            Outbound.Set(52, Clock.Time);
-            Outbound.Set(49, Configuration.Sender);
-            Outbound.Set(56, Configuration.Target);
-            Outbound.Build();
+            Outbound
+                .Prepare("5")
+                .Set(34, State.OutboundSeqNum)
+                .Set(52, Clock.Time)
+                .Set(49, Configuration.Sender)
+                .Set(56, Configuration.Target)
+                .Build();
 
             Send(State, Channel, Outbound);
 
@@ -170,12 +171,13 @@ namespace HotFix.Core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SendHeartbeat(IConfiguration configuration, State state, Channel channel, FIXMessageWriter outbound)
         {
-            outbound.Prepare("0");
-            outbound.Set(34, state.OutboundSeqNum);
-            outbound.Set(52, Clock.Time);
-            outbound.Set(49, configuration.Sender);
-            outbound.Set(56, configuration.Target);
-            outbound.Build();
+            outbound
+                .Prepare("0")
+                .Set(34, state.OutboundSeqNum)
+                .Set(52, Clock.Time)
+                .Set(49, configuration.Sender)
+                .Set(56, configuration.Target)
+                .Build();
 
             Send(state, channel, outbound);
         }
@@ -183,13 +185,14 @@ namespace HotFix.Core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SendTestRequest(IConfiguration configuration, State state, Channel channel, FIXMessageWriter outbound)
         {
-            outbound.Prepare("1");
-            outbound.Set(34, state.OutboundSeqNum);
-            outbound.Set(52, Clock.Time);
-            outbound.Set(49, configuration.Sender);
-            outbound.Set(56, configuration.Target);
-            outbound.Set(112, Clock.Time.Ticks);
-            outbound.Build();
+            outbound
+                .Prepare("1")
+                .Set(34, state.OutboundSeqNum)
+                .Set(52, Clock.Time)
+                .Set(49, configuration.Sender)
+                .Set(56, configuration.Target)
+                .Set(112, Clock.Time.Ticks)
+                .Build();
 
             Send(state, channel, outbound);
         }
@@ -199,14 +202,15 @@ namespace HotFix.Core
         {
             if (state.Synchronizing) return;
 
-            outbound.Prepare("2");
-            outbound.Set(34, state.OutboundSeqNum);
-            outbound.Set(52, Clock.Time);
-            outbound.Set(49, configuration.Sender);
-            outbound.Set(56, configuration.Target);
-            outbound.Set(7, state.InboundSeqNum);
-            outbound.Set(16, 0);
-            outbound.Build();
+            outbound
+                .Prepare("2")
+                .Set(34, state.OutboundSeqNum)
+                .Set(52, Clock.Time)
+                .Set(49, configuration.Sender)
+                .Set(56, configuration.Target)
+                .Set(7, state.InboundSeqNum)
+                .Set(16, 0)
+                .Build();
 
             Send(state, channel, outbound);
 
@@ -217,13 +221,14 @@ namespace HotFix.Core
         public void HandleTestRequest(IConfiguration configuration, State state, Channel channel, FIXMessage inbound, FIXMessageWriter outbound)
         {
             // Prepare and send a heartbeat (with the test request id)
-            outbound.Prepare("0");
-            outbound.Set(34, state.OutboundSeqNum);
-            outbound.Set(52, Clock.Time);
-            outbound.Set(49, configuration.Sender);
-            outbound.Set(56, configuration.Target);
-            outbound.Set(112, inbound[112].AsString);
-            outbound.Build();
+            outbound
+                .Prepare("0")
+                .Set(34, state.OutboundSeqNum)
+                .Set(52, Clock.Time)
+                .Set(49, configuration.Sender)
+                .Set(56, configuration.Target)
+                .Set(112, inbound[112].AsString)
+                .Build();
 
             Send(state, channel, outbound);
         }
@@ -235,14 +240,15 @@ namespace HotFix.Core
             if (!inbound[16].Is(0L)) throw new EngineException("Unsupported resend request received (partial gap fills are not supported)");
 
             // Prepare and send a gap fill message
-            outbound.Prepare("4");
-            outbound.Set(34, inbound[7].AsLong);
-            outbound.Set(52, Clock.Time);
-            outbound.Set(49, configuration.Sender);
-            outbound.Set(56, configuration.Target);
-            outbound.Set(123, "Y");
-            outbound.Set(36, state.OutboundSeqNum);
-            outbound.Build();
+            outbound
+                .Prepare("4")
+                .Set(34, inbound[7].AsLong)
+                .Set(52, Clock.Time)
+                .Set(49, configuration.Sender)
+                .Set(56, configuration.Target)
+                .Set(123, "Y")
+                .Set(36, state.OutboundSeqNum)
+                .Build();
 
             Send(state, channel, outbound);
 
@@ -300,15 +306,16 @@ namespace HotFix.Core
 
                     if (Inbound[34].AsLong < state.InboundSeqNum) throw new EngineException("Sequence number too low");
 
-                    Outbound.Prepare("A");
-                    Outbound.Set(34, state.OutboundSeqNum);
-                    Outbound.Set(52, Clock.Time);
-                    Outbound.Set(49, configuration.Sender);
-                    Outbound.Set(56, configuration.Target);
-                    Outbound.Set(108, Configuration.HeartbeatInterval);
-                    Outbound.Set(98, 0);
-                    Outbound.Set(141, "Y");
-                    Outbound.Build();
+                    outbound
+                        .Prepare("A")
+                        .Set(34, state.OutboundSeqNum)
+                        .Set(52, Clock.Time)
+                        .Set(49, configuration.Sender)
+                        .Set(56, configuration.Target)
+                        .Set(108, Configuration.HeartbeatInterval)
+                        .Set(98, 0)
+                        .Set(141, "Y")
+                        .Build();
 
                     Send(state, channel, outbound);
 
@@ -331,15 +338,16 @@ namespace HotFix.Core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void InitiateLogon(IConfiguration configuration, State state, Channel channel, FIXMessage inbound, FIXMessageWriter outbound)
         {
-            outbound.Prepare("A");
-            outbound.Set(34, state.OutboundSeqNum);
-            outbound.Set(52, Clock.Time);
-            outbound.Set(49, configuration.Sender);
-            outbound.Set(56, configuration.Target);
-            outbound.Set(108, configuration.HeartbeatInterval);
-            outbound.Set(98, 0);
-            outbound.Set(141, "Y");
-            outbound.Build();
+            outbound
+                .Prepare("A")
+                .Set(34, state.OutboundSeqNum)
+                .Set(52, Clock.Time)
+                .Set(49, configuration.Sender)
+                .Set(56, configuration.Target)
+                .Set(108, Configuration.HeartbeatInterval)
+                .Set(98, 0)
+                .Set(141, "Y")
+                .Build();
 
             Send(state, channel, outbound);
 

--- a/HotFix/Program.cs
+++ b/HotFix/Program.cs
@@ -84,15 +84,10 @@ namespace HotFix
                         for (var i = 0; i < 100; i++)
                         {
                             message
-                                .Prepare("X")
-                                .Set(34, Acceptor.State.OutboundSeqNum)
-                                .Set(52, Acceptor.Clock.Time)
-                                .Set(49, Acceptor.Configuration.Sender)
-                                .Set(56, Acceptor.Configuration.Target)
-                                .Set(999, Acceptor.Clock.Time.Ticks)
-                                .Build();
+                                .Clear()
+                                .Set(999, Acceptor.Clock.Time.Ticks);
 
-                            Acceptor.Send(Acceptor.State, Acceptor.Channel, message);
+                            Acceptor.Send("X", Acceptor.State, Acceptor.Channel, message);
                         }
                     }
                 }

--- a/HotFix/Program.cs
+++ b/HotFix/Program.cs
@@ -83,13 +83,14 @@ namespace HotFix
 
                         for (var i = 0; i < 100; i++)
                         {
-                            message.Prepare("X");
-                            message.Set(34, Acceptor.State.OutboundSeqNum);
-                            message.Set(52, Acceptor.Clock.Time);
-                            message.Set(49, Acceptor.Configuration.Sender);
-                            message.Set(56, Acceptor.Configuration.Target);
-                            message.Set(999, Acceptor.Clock.Time.Ticks);
-                            message.Build();
+                            message
+                                .Prepare("X")
+                                .Set(34, Acceptor.State.OutboundSeqNum)
+                                .Set(52, Acceptor.Clock.Time)
+                                .Set(49, Acceptor.Configuration.Sender)
+                                .Set(56, Acceptor.Configuration.Target)
+                                .Set(999, Acceptor.Clock.Time.Ticks)
+                                .Build();
 
                             Acceptor.Send(Acceptor.State, Acceptor.Channel, message);
                         }


### PR DESCRIPTION
- Message writer returns itself for chaining calls to the writer
- Changed all occurrences of message building to use the fluent api
- Restructured message writer API
  - Standard header tags are now added at the end
  - The session takes care of adding the standard header
- Renamed message writer fields according to convention