### PR TITLE
Feature/logger

### DIFF
--- a/HotFix.Demo.Acceptor/Program.cs
+++ b/HotFix.Demo.Acceptor/Program.cs
@@ -24,7 +24,8 @@ namespace HotFix.Demo.Acceptor
                 Target = "Client",
                 InboundSeqNum = 1,
                 OutboundSeqNum = 1,
-                HeartbeatInterval = 86400
+                HeartbeatInterval = 86400,
+                //LogFile = @"messages.log" // Enable to see logging impact
             };
 
             using (var session = engine.Open(configuration))

--- a/HotFix.Demo.Initiator/Program.cs
+++ b/HotFix.Demo.Initiator/Program.cs
@@ -28,7 +28,8 @@ namespace HotFix.Demo.Initiator
                 Target = "Server",
                 InboundSeqNum = 1,
                 OutboundSeqNum = 1,
-                HeartbeatInterval = 86400
+                HeartbeatInterval = 86400,
+                //LogFile = @"messages.log" // Enable to see logging impact
             };
 
             using (var session = engine.Open(configuration))

--- a/HotFix/Core/Channel.cs
+++ b/HotFix/Core/Channel.cs
@@ -5,10 +5,13 @@ namespace HotFix.Core
 {
     /// <summary>
     /// A channel is a message layer abstraction over a transport, allowing messages
-    /// to be written and read from a transport
+    /// to be written and read from a transport.
     /// </summary>
     public class Channel
     {
+        public Action<byte[], int, int> Inbound { get; set; }
+        public Action<byte[], int, int> Outbound { get; set; }
+
         private const char SOH = '\u0001';
 
         private readonly byte[] _buffer;
@@ -18,6 +21,11 @@ namespace HotFix.Core
 
         public ITransport Transport { get; }
 
+        /// <summary>
+        /// Creates a new channel with the specified buffer for the provided transport.
+        /// </summary>
+        /// <param name="transport">The underlying transport.</param>
+        /// <param name="bufferSize">The buffer size.</param>
         public Channel(ITransport transport, int bufferSize)
         {
             Transport = transport;
@@ -26,10 +34,10 @@ namespace HotFix.Core
         }
 
         /// <summary>
-        /// Reads a message from the transport and returns true/false to indicate whether a valid message was read
+        /// Reads a message from the transport and returns true/false to indicate whether a valid message was read.
         /// </summary>
-        /// <param name="message"> The message to read into </param>
-        /// <returns> Whether a valid message was read </returns>
+        /// <param name="message">The message to read into.</param>
+        /// <returns>Whether a valid message was read.</returns>
         public bool Read(FIXMessage message)
         {
             if (_current == _head)
@@ -48,6 +56,8 @@ namespace HotFix.Core
                 if (_buffer[_current - 7] != SOH) continue;
 
                 message.Parse(_buffer, _tail, _current - _tail + 1);
+
+                Inbound?.Invoke(_buffer, _tail, _current - _tail + 1);
 
                 _tail = _current + 1;
 
@@ -75,12 +85,13 @@ namespace HotFix.Core
         }
 
         /// <summary>
-        /// Writes a message to the transport
+        /// Writes a message to the transport.
         /// </summary>
-        /// <param name="message"> The message to write </param>
+        /// <param name="message">The message to write.</param>
         public void Write(FIXMessageWriter message)
         {
             Transport.Write(message.Buffer, 0, message.Length);
+            Outbound?.Invoke(message.Buffer, 0, message.Length);
         }
     }
 }

--- a/HotFix/Core/Configuration.cs
+++ b/HotFix/Core/Configuration.cs
@@ -14,8 +14,9 @@ namespace HotFix.Core
         public int Port { get; set; }
 
         public int HeartbeatInterval { get; set; }
-
         public long InboundSeqNum { get; set; }
         public long OutboundSeqNum { get; set; }
+
+        public string LogFile { get; set; }
     }
 }

--- a/HotFix/Core/IConfiguration.cs
+++ b/HotFix/Core/IConfiguration.cs
@@ -16,5 +16,7 @@ namespace HotFix.Core
         int HeartbeatInterval { get; set; }
         long InboundSeqNum { get; set; }
         long OutboundSeqNum { get; set; }
+
+        string LogFile { get; set; }
     }
 }

--- a/HotFix/HotFix.csproj
+++ b/HotFix/HotFix.csproj
@@ -65,6 +65,8 @@
     <Compile Include="Transport\ConsoleTransport.cs" />
     <Compile Include="Transport\ITransport.cs" />
     <Compile Include="Transport\TcpTransport.cs" />
+    <Compile Include="Utilities\FileLogger.cs" />
+    <Compile Include="Utilities\ILogger.cs" />
     <Compile Include="Utilities\RealTimeClock.cs" />
     <Compile Include="Utilities\IClock.cs" />
     <Compile Include="Utilities\Os.cs" />

--- a/HotFix/Utilities/FileLogger.cs
+++ b/HotFix/Utilities/FileLogger.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using HotFix.Encoding;
+
+namespace HotFix.Utilities
+{
+    /// <summary>
+    /// A file logger.
+    /// <remarks>
+    /// Thread safe and garbage free.
+    /// </remarks>
+    /// </summary>
+    public class FileLogger : ILogger
+    {
+        private readonly IClock _clock;
+        private readonly FileStream _file;
+        private readonly byte[] _inbound = new byte[26];
+        private readonly byte[] _outbound = new byte[26];
+
+        /// <summary>
+        /// Creates a new instance of the file logger.
+        /// </summary>
+        /// <param name="clock">A clock to use for log entries.</param>
+        /// <param name="file">The file to log to.</param>
+        public FileLogger(IClock clock, string file)
+        {
+            _clock = clock;
+            _file = new FileStream(file, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read, 4096, FileOptions.SequentialScan);
+
+            _inbound[0] = (byte)'\r';
+            _inbound[1] = (byte)'\n';
+            // Reserved space for timestamp
+            _inbound[23] = (byte)' ';
+            _inbound[24] = (byte)'<';
+            _inbound[25] = (byte)' ';
+
+            _outbound[0] = (byte)'\r';
+            _outbound[1] = (byte)'\n';
+            // Reserved space for timestamp
+            _outbound[23] = (byte)' ';
+            _outbound[24] = (byte)'>';
+            _outbound[25] = (byte)' ';
+        }
+
+        /// <summary>
+        /// Logs an inbound message within the specified boundaries in the provided buffer to the underlying log file.
+        /// <remarks>
+        /// The underlying log file will be soft flushed once the log line is written.
+        /// </remarks>
+        /// </summary>
+        /// <param name="buffer">The buffer containing the message.</param>
+        /// <param name="offset">The offset where the message starts.</param>
+        /// <param name="length">The length of the message.</param>
+        public void Inbound(byte[] buffer, int offset, int length)
+        {
+            if (!_file.CanWrite) throw new Exception("The log file cannot be written to");
+
+            lock (_file)
+            {
+                _inbound.WriteDateTime(2, _clock.Time);
+
+                _file.Write(_inbound, 0, 26);
+                _file.Write(buffer, offset, length);
+
+                _file.Flush();
+            }
+        }
+
+        /// <summary>
+        /// Logs an outbound message within the specified boundaries in the provided buffer to the underlying log file.
+        /// <remarks>
+        /// The underlying log file will be soft flushed once the log line is written.
+        /// </remarks>
+        /// </summary>
+        /// <param name="buffer">The buffer containing the message.</param>
+        /// <param name="offset">The offset where the message starts.</param>
+        /// <param name="length">The length of the message.</param>
+        public void Outbound(byte[] buffer, int offset, int length)
+        {
+            if (!_file.CanWrite) throw new Exception("The log file cannot be written to");
+
+            lock (_file)
+            {
+                _outbound.WriteDateTime(2, _clock.Time);
+
+                _file.Write(_outbound, 0, 26);
+                _file.Write(buffer, offset, length);
+
+                _file.Flush();
+            }
+        }
+
+        /// <summary>
+        /// Disposes the logger and the underlying file.
+        /// <remarks>
+        /// The underlying file will be hard flushed to disk first.
+        /// </remarks>
+        /// </summary>
+        public void Dispose()
+        {
+            _file.Flush(true);
+            _file?.Dispose();
+        }
+    }
+}

--- a/HotFix/Utilities/ILogger.cs
+++ b/HotFix/Utilities/ILogger.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace HotFix.Utilities
+{
+    /// <summary>
+    /// An abstraction for message logging.
+    /// </summary>
+    public interface ILogger : IDisposable
+    {
+        /// <summary>
+        /// Logs an inbound message within the specified boundaries in the provided buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer containing the message.</param>
+        /// <param name="offset">The offset where the message starts.</param>
+        /// <param name="length">The length of the message.</param>
+        void Inbound(byte[] buffer, int offset, int length);
+
+        /// <summary>
+        /// Logs an outbound message within the specified boundaries in the provided buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer containing the message.</param>
+        /// <param name="offset">The offset where the message starts.</param>
+        /// <param name="length">The length of the message.</param>
+        void Outbound(byte[] buffer, int offset, int length);
+    }
+}


### PR DESCRIPTION
- Added setting `LogFile` in configuration file
    - If specified, a file logger will be used (see below)
    - If not specified (null), logging is no-op
- Added logger abstraction
    - The logger logs inbound and outbound messages
- Added logger implementation (**file logger**)
    - Logs inbound and outbound messages in the format:
        - `20170706-10:32:40.375 < ...` - inbound
        - `20170706-10:32:40.376 > ...` - outbound
    - Allocation/garbage free implementation
- Performance impact:
    - Null logging has almost no overhead
    - File logging adds about 3 µs per message written
- Demo applications have logging disabled by default