### PR TITLE
Write message to byte array methods

### DIFF
--- a/HotFix.Test/HotFix.Test.csproj
+++ b/HotFix.Test/HotFix.Test.csproj
@@ -68,8 +68,10 @@
     <Compile Include="core\field\checking_the_value_for_integer_equality.cs" />
     <Compile Include="core\field\checking_the_value_for_long_equality.cs" />
     <Compile Include="core\field\checking_the_value_for_string_equality.cs" />
+    <Compile Include="core\messagewriter\writing_to_a_byte_array.cs" />
     <Compile Include="core\message\check_for_a_field.cs" />
     <Compile Include="core\message\converting_to_string.cs" />
+    <Compile Include="core\message\writing_to_a_byte_array.cs" />
     <Compile Include="utilities\reading\datetimes.cs" />
     <Compile Include="utilities\reading\floats.cs" />
     <Compile Include="utilities\reading\ints.cs" />

--- a/HotFix.Test/core/message/writing_to_a_byte_array.cs
+++ b/HotFix.Test/core/message/writing_to_a_byte_array.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using FluentAssertions;
+using HotFix.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HotFix.Test.core.message
+{
+    [TestClass]
+    public class writing_to_a_byte_array
+    {
+        [TestMethod]
+        public void writes_the_whole_message_to_the_given_buffer_starting_at_the_correct_offset()
+        {
+            var message = new FIXMessage();
+            var logon = "8=FIX.4.2|9=70|35=A|34=1|52=20170607-12:17:52.355|49=DAEV|56=TARGET|98=0|108=5|141=Y|10=231|".Replace("|", "\u0001");
+            var bytes = System.Text.Encoding.ASCII.GetBytes(logon);
+            var target = new byte[100];
+
+            message
+                .Parse(bytes, 0, bytes.Length)
+                .WriteTo(target, 3);
+
+            var result = System.Text.Encoding.ASCII.GetString(target);
+
+            result.Should().Be("\0\0\0" + logon + "\0\0\0\0\0");
+        }
+    }
+}

--- a/HotFix.Test/core/messagewriter/writing_to_a_byte_array.cs
+++ b/HotFix.Test/core/messagewriter/writing_to_a_byte_array.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using FluentAssertions;
+using HotFix.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HotFix.Test.core.messagewriter
+{
+    [TestClass]
+    public class writing_to_a_byte_array
+    {
+        [TestMethod]
+        public void writes_the_whole_message_to_the_given_buffer_starting_at_the_correct_offset()
+        {
+            var message = new FIXMessageWriter(1000);
+            var logon = "8=FIX.4.2|9=00069|35=A|34=177|52=20090107-18:15:16.000|49=SERVER|56=CLIENT|98=0|108=30|10=144|".Replace("|", "\u0001");
+            var target = new byte[100];
+
+            message
+                .Set(98, 0)
+                .Set(108, 30)
+                .Prepare("FIX.4.2", "A", 177, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null), "SERVER", "CLIENT")
+                .WriteTo(target, 3);
+
+            var result = System.Text.Encoding.ASCII.GetString(target);
+            result.Should().Be("\0\0\0" + logon + "\0\0\0");
+        }
+    }
+}

--- a/HotFix/Core/FIXMessage.cs
+++ b/HotFix/Core/FIXMessage.cs
@@ -234,5 +234,10 @@ namespace HotFix.Core
         {
             return System.Text.Encoding.ASCII.GetString(Raw, 0, Length);
         }
+
+        public void WriteTo(byte[] target, int offset)
+        {
+            Buffer.BlockCopy(Raw, 0, target, offset, Length);
+        }
     }
 }

--- a/HotFix/Core/FIXMessageWriter.cs
+++ b/HotFix/Core/FIXMessageWriter.cs
@@ -161,6 +161,14 @@ namespace HotFix.Core
             return checksum % 256;
         }
 
-        public override string ToString() => System.Text.Encoding.ASCII.GetString(Buffer, 0, Length);
+        public override string ToString()
+        {
+            return System.Text.Encoding.ASCII.GetString(Buffer, 0, Length);
+        }
+
+        public void WriteTo(byte[] target, int offset)
+        {
+            System.Buffer.BlockCopy(Buffer, 0, target, offset, Length);
+        }
     }
 }


### PR DESCRIPTION
Added a method to the message parser and writer that copies the message from the internal byte array to another one.

This functionality is intended to allow zero-garbage transfer of the message data, as an alternative to the `ToString()` method which is currently the only way to get the raw data out of the message parser/writer.