### PR TITLE
Feature/heartbeat interval zero

### DIFF
--- a/HotFix.Demo.Acceptor/Program.cs
+++ b/HotFix.Demo.Acceptor/Program.cs
@@ -24,7 +24,7 @@ namespace HotFix.Demo.Acceptor
                 Target = "Client",
                 InboundSeqNum = 1,
                 OutboundSeqNum = 1,
-                HeartbeatInterval = 86400,
+                HeartbeatInterval = 0,
                 //LogFile = @"messages.log" // Enable to see logging impact
             };
 

--- a/HotFix.Demo.Initiator/Program.cs
+++ b/HotFix.Demo.Initiator/Program.cs
@@ -28,7 +28,7 @@ namespace HotFix.Demo.Initiator
                 Target = "Server",
                 InboundSeqNum = 1,
                 OutboundSeqNum = 1,
-                HeartbeatInterval = 86400,
+                HeartbeatInterval = 0,
                 //LogFile = @"messages.log" // Enable to see logging impact
             };
 

--- a/HotFix.Specification/heartbeat/heartbeat.cs
+++ b/HotFix.Specification/heartbeat/heartbeat.cs
@@ -50,5 +50,49 @@ namespace HotFix.Specification.heartbeat
                 })
                 .Run();
         }
+
+        [TestMethod]
+        public void is_not_sent_when_the_heartbeat_interval_is_zero()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Initiator,
+                    Version = "FIX.4.2",
+                    Sender = "Client",
+                    Target = "Server",
+                    HeartbeatInterval = 0,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:45.012",
+                    // The engine should sent a valid logon message first
+                    "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:45.012|49=Client|56=Server|108=0|98=0|141=Y|10=089|",
+                    "! 20170623-14:51:45.051",
+                    // The engine should accept the target's logon response
+                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=0|98=0|141=Y|10=204|",
+                    "! 20170623-14:51:46.000",
+                    "! 20170623-14:51:47.000",
+                    "! 20170623-14:51:48.000",
+                    "! 20170623-14:51:49.000",
+                    "! 20170623-14:51:50.000",
+                    "! 20170623-14:51:55.000",
+                    "! 20170623-14:52:00.000",
+                    "! 20170623-14:52:30.000",
+                    "! 20170623-14:53:00.000",
+                    "! 20170623-14:54:00.000",
+                    "! 20170623-14:55:00.000",
+                    // The engine should not send heartbeats even though a lot of time passes
+                    "! 20170623-15:00:00.000"
+                })
+                .Verify((session, configuration, _) =>
+                {
+                    session.State.InboundSeqNum.Should().Be(2);
+                    session.State.OutboundSeqNum.Should().Be(2);
+                })
+                .Run();
+        }
     }
 }

--- a/HotFix.Specification/test_request/an_outbound_test_request.cs
+++ b/HotFix.Specification/test_request/an_outbound_test_request.cs
@@ -10,6 +10,48 @@ namespace HotFix.Specification.test_request
     public class an_outbound_test_request
     {
         [TestMethod]
+        public void is_not_sent_when_the_heartbeat_interval_is_zero()
+        {
+            new Specification()
+                .Configure(new Configuration
+                {
+                    Role = Role.Initiator,
+                    Version = "FIX.4.2",
+                    Sender = "Client",
+                    Target = "Server",
+                    HeartbeatInterval = 0,
+                    OutboundSeqNum = 1,
+                    InboundSeqNum = 1
+                })
+                .Steps(new List<string>
+                {
+                    "! 20170623-14:51:45.012",
+                    "> 8=FIX.4.2|9=00072|35=A|34=1|52=20170623-14:51:45.012|49=Client|56=Server|108=0|98=0|141=Y|10=089|",
+                    "! 20170623-14:51:45.051",
+                    "< 8=FIX.4.2|9=72|35=A|34=1|49=Server|52=20170623-14:51:45.051|56=Client|108=0|98=0|141=Y|10=204|",
+                    "! 20170623-14:51:46.000",
+                    "! 20170623-14:51:47.000",
+                    "! 20170623-14:51:48.000",
+                    "! 20170623-14:51:49.000",
+                    "! 20170623-14:51:50.000",
+                    "! 20170623-14:51:55.000",
+                    "! 20170623-14:52:00.000",
+                    "! 20170623-14:52:30.000",
+                    "! 20170623-14:53:00.000",
+                    "! 20170623-14:54:00.000",
+                    "! 20170623-14:55:00.000",
+                    // The engine should not send test requests even though a lot of time passes
+                    "! 20170623-15:00:00.000"
+                })
+                .Verify((session, configuration, _) =>
+                {
+                    session.State.InboundSeqNum.Should().Be(2);
+                    session.State.OutboundSeqNum.Should().Be(2);
+                })
+                .Run();
+        }
+
+        [TestMethod]
         public void is_sent_when_no_messages_have_been_received_for_slightly_longer_than_the_heartbeat_interval()
         {
             new Specification()

--- a/HotFix/Core/Session.cs
+++ b/HotFix/Core/Session.cs
@@ -147,19 +147,22 @@ namespace HotFix.Core
                 }
             }
 
-            if (clock.Time - state.OutboundTimestamp > state.HeartbeatInterval)
+            if (state.HeartbeatInterval != TimeSpan.Zero)
             {
-                SendHeartbeat();
-            }
-
-            if (clock.Time - state.InboundTimestamp > state.HeartbeatTimeoutMin)
-            {
-                if (clock.Time - state.InboundTimestamp > state.HeartbeatTimeoutMax)
+                if (clock.Time - state.OutboundTimestamp > state.HeartbeatInterval)
                 {
-                    throw new EngineException("Did not receive any messages for too long");
+                    SendHeartbeat();
                 }
 
-                if (!state.TestRequestPending) SendTestRequest();
+                if (clock.Time - state.InboundTimestamp > state.HeartbeatTimeoutMin)
+                {
+                    if (clock.Time - state.InboundTimestamp > state.HeartbeatTimeoutMax)
+                    {
+                        throw new EngineException("Did not receive any messages for too long");
+                    }
+
+                    if (!state.TestRequestPending) SendTestRequest();
+                }
             }
 
             return inbound.Valid;


### PR DESCRIPTION
- Heartbeat interval can now be zero
    - Outbound heartbeats are not sent
    - Inbound heartbeats are not timed out
- Added specifications tests to
    - Ensure we do not send heartbeats
    - Ensure we do not send test requests or time out the connection
- Used zero heartbeat interval in demo apps