### PR TITLE
Feature/tcp fastpath fix

### DIFF
--- a/HotFix/Transport/TcpTransport.cs
+++ b/HotFix/Transport/TcpTransport.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Net;
 using System.Net.Sockets;
+using HotFix.Utilities;
 
 namespace HotFix.Transport
 {
     public class TcpTransport : ITransport
     {
-        const int SIO_LOOPBACK_FAST_PATH = -1744830448;
-
         private readonly NetworkStream _stream;
 
         public static TcpTransport Create(bool server, string address, int port)
@@ -20,7 +19,7 @@ namespace HotFix.Transport
             var endpoint = new IPEndPoint(IPAddress.Parse(address), port);
             var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp) { ReceiveTimeout = 1000, NoDelay = true };
 
-            socket.IOControl(SIO_LOOPBACK_FAST_PATH, BitConverter.GetBytes(1), null);
+            socket.EnableFastPath();
             socket.Connect(endpoint);
 
             return new TcpTransport(new NetworkStream(socket, true));
@@ -31,7 +30,7 @@ namespace HotFix.Transport
             var endpoint = new IPEndPoint(IPAddress.Parse(address), port);
             var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp) { ReceiveTimeout = 1000, NoDelay = true };
 
-            socket.IOControl(SIO_LOOPBACK_FAST_PATH, BitConverter.GetBytes(1), null);
+            socket.EnableFastPath();
             socket.Bind(endpoint);
             socket.Listen(1);
 

--- a/HotFix/Utilities/Os.cs
+++ b/HotFix/Utilities/Os.cs
@@ -1,11 +1,35 @@
 ﻿using System;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
 
 namespace HotFix.Utilities
 {
     internal static class Os
     {
+        internal const int SIO_LOOPBACK_FAST_PATH = -1744830448;
+        internal const int WSAEOPNOTSUPP = 10045;
+
         [DllImport("Kernel32.dll", CallingConvention = CallingConvention.Winapi)]
         internal static extern void GetSystemTimePreciseAsFileTime(out long filetime);
+
+        /// <summary>
+        /// Attempts to enable the fast path for localhost.
+        /// <remarks>
+        /// Does nothing if unavailable on the current platform.
+        /// </remarks>
+        /// </summary>
+        /// <param name="socket">The socket.</param>
+        internal static void EnableFastPath(this Socket socket)
+        {
+            try
+            {
+                // Attempt to set fast loopback if available
+                socket.IOControl(SIO_LOOPBACK_FAST_PATH, BitConverter.GetBytes(1), null);
+            }
+            catch (SocketException e)
+            {
+                if (e.ErrorCode != WSAEOPNOTSUPP) throw;
+            }
+        }
     }
 }


### PR DESCRIPTION
- Moved FAST_PATH function to OS extension methods (as it is OS dependent)
- Swallow errors when FAST_PATH is not available (Linux and < Windows 8)

Related to #51 