### PR TITLE
Hotfix/0.2.1

### DIFF
--- a/HotFix.Benchmark/suites/session/session_receive.cs
+++ b/HotFix.Benchmark/suites/session/session_receive.cs
@@ -65,7 +65,7 @@ namespace HotFix.Benchmark.suites.session
             };
 
             Transport = new Canned();
-            Session = new Session(Configuration, new RealTimeClock(), Transport, 65536, 4096, 1024);
+            Session = new Session(Configuration, new RealTimeClock(), Transport, null, 65536, 4096, 1024);
         }
 
         public Configuration Configuration;

--- a/HotFix/Core/Engine.cs
+++ b/HotFix/Core/Engine.cs
@@ -47,13 +47,7 @@ namespace HotFix.Core
             var logger = Loggers(configuration);
             var transport = Transports(configuration);
 
-            var session = new Session(configuration, clock, transport, BufferSize, MaxMessageLength, MaxMessageFields);
-
-            if (logger != null)
-            {
-                session.Channel.Inbound = logger.Inbound;
-                session.Channel.Outbound = logger.Outbound;
-            }
+            var session = new Session(configuration, clock, transport, logger, BufferSize, MaxMessageLength, MaxMessageFields);
 
             return session;
         }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@
   build:
     verbosity: normal
 - 
-  version: 0.2.0.{build}
+  version: 0.2.1.{build}
   branches:
     only:
     - master


### PR DESCRIPTION
- Ensured logger gets disposed with the session
    - Session given reference to logger
    - Session hooks up the logger to the channel
    - Session disposes the logger when it is disposed

> There was a bug where the session could not be restarted because the log file was still locked by the original (undisposed) logger. This should fix that...

