### PR TITLE
Introduced a helper method for DateTime string "literals"

### DIFF
--- a/HotFix.Test/HelperExtensions.cs
+++ b/HotFix.Test/HelperExtensions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using static System.Globalization.DateTimeStyles;
+
+namespace HotFix.Test
+{
+    public static class HelperExtensions
+    {
+        public static DateTime AsDateTime(this string date) => DateTime.ParseExact(date, "yyyy/MM/dd HH:mm:ss.fff", null, AssumeUniversal | AdjustToUniversal);
+    }
+}

--- a/HotFix.Test/HotFix.Test.csproj
+++ b/HotFix.Test/HotFix.Test.csproj
@@ -72,6 +72,7 @@
     <Compile Include="core\message\check_for_a_field.cs" />
     <Compile Include="core\message\converting_to_string.cs" />
     <Compile Include="core\message\writing_to_a_byte_array.cs" />
+    <Compile Include="HelperExtensions.cs" />
     <Compile Include="utilities\reading\datetimes.cs" />
     <Compile Include="utilities\reading\floats.cs" />
     <Compile Include="utilities\reading\ints.cs" />

--- a/HotFix.Test/core/field/checking_the_value_for_datetime_equality.cs
+++ b/HotFix.Test/core/field/checking_the_value_for_datetime_equality.cs
@@ -13,7 +13,7 @@ namespace HotFix.Test.core.field
         {
             var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=XXXXXX-YY:YY:YY.ZZZ\u0001"), 0, new Segment(3, 21), 25, 0);
 
-            field.Is(DateTime.ParseExact("27/03/2017 09:34:21.456", "dd/MM/yyyy HH:mm:ss.fff", null)).Should().Be(false);
+            field.Is("2017/03/27 09:34:21.456".AsDateTime()).Should().Be(false);
         }
 
         [TestMethod]
@@ -21,7 +21,7 @@ namespace HotFix.Test.core.field
         {
             var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=20170423-12:32:23.123\u0001"), 0, new Segment(3, 21), 25, 0);
 
-            field.Is(DateTime.ParseExact("27/03/2017 09:34:21.456", "dd/MM/yyyy HH:mm:ss.fff", null)).Should().Be(false);
+            field.Is("2017/03/27 09:34:21.456".AsDateTime()).Should().Be(false);
         }
 
         [TestMethod]
@@ -29,7 +29,7 @@ namespace HotFix.Test.core.field
         {
             var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=20170327-09:34:21.456\u0001"), 0, new Segment(3, 21), 25, 0);
 
-            field.Is(DateTime.ParseExact("27/03/2017 09:34:21.456", "dd/MM/yyyy HH:mm:ss.fff", null)).Should().Be(true);
+            field.Is("2017/03/27 09:34:21.456".AsDateTime()).Should().Be(true);
         }
     }
 }

--- a/HotFix.Test/core/messagewriter/building_a_message.cs
+++ b/HotFix.Test/core/messagewriter/building_a_message.cs
@@ -16,7 +16,7 @@ namespace HotFix.Test.core.messagewriter
             message
                 .Set(98, 0)
                 .Set(108, 30)
-                .Prepare("FIX.4.2", "A", 177, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null), "SERVER", "CLIENT");
+                .Prepare("FIX.4.2", "A", 177, "2009/01/07 18:15:16.000".AsDateTime(), "SERVER", "CLIENT");
 
             var str = message.ToString();
 
@@ -30,7 +30,7 @@ namespace HotFix.Test.core.messagewriter
 
             // Prepare and build a small message
             message
-                .Prepare("FIX.4.2", "0", 8059, DateTime.ParseExact("2017/05/31 08:18:01.767", "yyyy/MM/dd HH:mm:ss.fff", null), "SENDER....", "RECEIVER.....");
+                .Prepare("FIX.4.2", "0", 8059, "2017/05/31 08:18:01.767".AsDateTime(), "SENDER....", "RECEIVER.....");
 
             var message1 = message.ToString();
 
@@ -40,7 +40,7 @@ namespace HotFix.Test.core.messagewriter
                 .Set(98, 0)
                 .Set(108, 30)
                 .Set(12345, "Some really long text to make the message really large sdkfjfkjs gfsabf sabf sahfvb ksdjflsahfpieghpEIGHXKJVB KLSGBS BHJUXVCJDV V JV jsdh fkasdgsadoas oghoash go iasg fcblxc nsleiso bnlzxcvn skjbg")
-                .Prepare("FIX.4.2", "A", 177, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null), "SERVER", "CLIENT");
+                .Prepare("FIX.4.2", "A", 177, "2009/01/07 18:15:16.000".AsDateTime(), "SERVER", "CLIENT");
 
             var message2 = message.ToString();
 
@@ -59,14 +59,14 @@ namespace HotFix.Test.core.messagewriter
                 .Set(98, 0)
                 .Set(108, 30)
                 .Set(12345, "Some really long text to make the message really large sdkfjfkjs gfsabf sabf sahfvb ksdjflsahfpieghpEIGHXKJVB KLSGBS BHJUXVCJDV V JV jsdh fkasdgsadoas oghoash go iasg fcblxc nsleiso bnlzxcvn skjbg")
-                .Prepare("FIX.4.2", "A", 177, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null), "SERVER", "CLIENT");
+                .Prepare("FIX.4.2", "A", 177, "2009/01/07 18:15:16.000".AsDateTime(), "SERVER", "CLIENT");
 
             var message1 = message.ToString();
 
             // Prepare and build a smaller message
             message
                 .Clear()
-                .Prepare("FIX.4.2", "0", 8059, DateTime.ParseExact("2017/05/31 08:18:01.767", "yyyy/MM/dd HH:mm:ss.fff", null), "SENDER....", "RECEIVER.....");
+                .Prepare("FIX.4.2", "0", 8059, "2017/05/31 08:18:01.767".AsDateTime(), "SENDER....", "RECEIVER.....");
 
             var message2 = message.ToString();
 

--- a/HotFix.Test/core/messagewriter/writing_to_a_byte_array.cs
+++ b/HotFix.Test/core/messagewriter/writing_to_a_byte_array.cs
@@ -18,7 +18,7 @@ namespace HotFix.Test.core.messagewriter
             message
                 .Set(98, 0)
                 .Set(108, 30)
-                .Prepare("FIX.4.2", "A", 177, DateTime.ParseExact("2009/01/07 18:15:16", "yyyy/MM/dd HH:mm:ss", null), "SERVER", "CLIENT")
+                .Prepare("FIX.4.2", "A", 177, "2009/01/07 18:15:16.000".AsDateTime(), "SERVER", "CLIENT")
                 .WriteTo(target, 3);
 
             var result = System.Text.Encoding.ASCII.GetString(target);

--- a/HotFix.Test/utilities/reading/datetimes.cs
+++ b/HotFix.Test/utilities/reading/datetimes.cs
@@ -13,7 +13,7 @@ namespace HotFix.Test.utilities.reading
         {
             var result = System.Text.Encoding.ASCII.GetBytes("20170327-15:45:13").ReadDateTime();
 
-            result.Should().Be(DateTime.ParseExact("27/03/2017 15:45:13", "dd/MM/yyyy HH:mm:ss", null));
+            result.Should().Be("2017/03/27 15:45:13.000".AsDateTime());
         }
 
         [TestMethod]
@@ -21,7 +21,7 @@ namespace HotFix.Test.utilities.reading
         {
             var result = System.Text.Encoding.ASCII.GetBytes("20170327-15:45:13.596").ReadDateTime();
 
-            result.Should().Be(DateTime.ParseExact("27/03/2017 15:45:13.596", "dd/MM/yyyy HH:mm:ss.fff", null));
+            result.Should().Be("2017/03/27 15:45:13.596".AsDateTime());
         }
     }
 }

--- a/HotFix.Test/utilities/scheduling/getting_the_active_scheduled_session.cs
+++ b/HotFix.Test/utilities/scheduling/getting_the_active_scheduled_session.cs
@@ -72,18 +72,18 @@ namespace HotFix.Test.utilities.scheduling
         [TestMethod]
         public void scenario_a()
         {
-            var schedule = _schedules.GetActive(DateTime.ParseExact("14/08/2017 08:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
+            var schedule = _schedules.GetActive("2017/08/14 08:00:00.000".AsDateTime());
 
             schedule.Should().NotBe(null);
             schedule.Name.Should().Be("Sunday");
-            schedule.Open.Should().Be(DateTime.ParseExact("13/08/2017 10:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
-            schedule.Close.Should().Be(DateTime.ParseExact("14/08/2017 10:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
+            schedule.Open.Should().Be("2017/08/13 10:00:00.000".AsDateTime());
+            schedule.Close.Should().Be("2017/08/14 10:00:00.000".AsDateTime());
         }
 
         [TestMethod]
         public void scenario_b()
         {
-            var schedule = _schedules.GetActive(DateTime.ParseExact("15/08/2017 08:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
+            var schedule = _schedules.GetActive("2017/08/15 08:00:00.000".AsDateTime());
 
             schedule.Should().Be(null);
         }
@@ -91,18 +91,18 @@ namespace HotFix.Test.utilities.scheduling
         [TestMethod]
         public void scenario_c()
         {
-            var schedule = _schedules.GetActive(DateTime.ParseExact("15/08/2017 12:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
+            var schedule = _schedules.GetActive("2017/08/15 12:00:00.000".AsDateTime());
 
             schedule.Should().NotBe(null);
             schedule.Name.Should().Be("Tuesday");
-            schedule.Open.Should().Be(DateTime.ParseExact("15/08/2017 10:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
-            schedule.Close.Should().Be(DateTime.ParseExact("16/08/2017 10:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
+            schedule.Open.Should().Be("2017/08/15 10:00:00.000".AsDateTime());
+            schedule.Close.Should().Be("2017/08/16 10:00:00.000".AsDateTime());
         }
 
         [TestMethod]
         public void scenario_d()
         {
-            var schedule = _schedules.GetActive(DateTime.ParseExact("16/08/2017 12:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
+            var schedule = _schedules.GetActive("2017/08/16 12:00:00.000".AsDateTime());
 
             schedule.Should().Be(null);
         }
@@ -110,34 +110,34 @@ namespace HotFix.Test.utilities.scheduling
         [TestMethod]
         public void scenario_e()
         {
-            var schedule = _schedules.GetActive(DateTime.ParseExact("18/08/2017 08:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
+            var schedule = _schedules.GetActive("2017/08/18 08:00:00.000".AsDateTime());
 
             schedule.Should().NotBe(null);
             schedule.Name.Should().Be("Thursday");
-            schedule.Open.Should().Be(DateTime.ParseExact("17/08/2017 10:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
-            schedule.Close.Should().Be(DateTime.ParseExact("19/08/2017 10:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
+            schedule.Open.Should().Be("2017/08/17 10:00:00.000".AsDateTime());
+            schedule.Close.Should().Be("2017/08/19 10:00:00.000".AsDateTime());
         }
 
         [TestMethod]
         public void scenario_f()
         {
-            var schedule = _schedules.GetActive(DateTime.ParseExact("19/08/2017 08:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
+            var schedule = _schedules.GetActive("2017/08/19 08:00:00.000".AsDateTime());
 
             schedule.Should().NotBe(null);
             schedule.Name.Should().Be("Thursday");
-            schedule.Open.Should().Be(DateTime.ParseExact("17/08/2017 10:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
-            schedule.Close.Should().Be(DateTime.ParseExact("19/08/2017 10:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
+            schedule.Open.Should().Be("2017/08/17 10:00:00.000".AsDateTime());
+            schedule.Close.Should().Be("2017/08/19 10:00:00.000".AsDateTime());
         }
 
         [TestMethod]
         public void scenario_g()
         {
-            var schedule = _schedules.GetActive(DateTime.ParseExact("20/08/2017 12:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
+            var schedule = _schedules.GetActive("2017/08/20 12:00:00.000".AsDateTime());
 
             schedule.Should().NotBe(null);
             schedule.Name.Should().Be("Sunday");
-            schedule.Open.Should().Be(DateTime.ParseExact("20/08/2017 10:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
-            schedule.Close.Should().Be(DateTime.ParseExact("21/08/2017 10:00:00.000", "dd/MM/yyyy HH:mm:ss.fff", null));
+            schedule.Open.Should().Be("2017/08/20 10:00:00.000".AsDateTime());
+            schedule.Close.Should().Be("2017/08/21 10:00:00.000".AsDateTime());
         }
     }
 }

--- a/HotFix.Test/utilities/writing/datetimes.cs
+++ b/HotFix.Test/utilities/writing/datetimes.cs
@@ -19,7 +19,7 @@ namespace HotFix.Test.utilities.writing
         [TestMethod]
         public void timestamp()
         {
-            var written = _buffer.WriteDateTime(1, DateTime.ParseExact("27/03/2017 15:45:13", "dd/MM/yyyy HH:mm:ss", null));
+            var written = _buffer.WriteDateTime(1, "2017/03/27 15:45:13.000".AsDateTime());
 
             System.Text.Encoding.ASCII.GetString(_buffer).Should().Be("\0" + "20170327-15:45:13.000" + "\0");
             written.Should().Be(21);
@@ -28,7 +28,7 @@ namespace HotFix.Test.utilities.writing
         [TestMethod]
         public void timestamp_with_milliseconds()
         {
-            var written = _buffer.WriteDateTime(1, DateTime.ParseExact("27/03/2017 15:45:13.123", "dd/MM/yyyy HH:mm:ss.fff", null));
+            var written = _buffer.WriteDateTime(1, "2017/03/27 15:45:13.123".AsDateTime());
 
             System.Text.Encoding.ASCII.GetString(_buffer).Should().Be("\0" + "20170327-15:45:13.123" + "\0");
             written.Should().Be(21);
@@ -38,7 +38,7 @@ namespace HotFix.Test.utilities.writing
         [ExpectedException(typeof(IndexOutOfRangeException))]
         public void out_of_bounds()
         {
-            _buffer.WriteDateTime(7, DateTime.ParseExact("27/03/2017 15:45:13.123", "dd/MM/yyyy HH:mm:ss.fff", null));
+            _buffer.WriteDateTime(7, "2017/03/27 15:45:13.123".AsDateTime());
         }
     }
 }


### PR DESCRIPTION
Introduced a helper extension method for `DateTime` string literals
 - Enforces a single format across all tests (yyyy/MM/dd HH:mm:ss.fff)
 - Replaces the long-winded `DateTime.ParseExact` method call
Replaced current `DateTime.ParseExact` usages in the test project with the extension method