### PR TITLE
Introduced shorthand for System.Text.Encoding.ASCII.GetBytes(...)

### DIFF
--- a/HotFix.Test/HelperExtensions.cs
+++ b/HotFix.Test/HelperExtensions.cs
@@ -6,5 +6,7 @@ namespace HotFix.Test
     public static class HelperExtensions
     {
         public static DateTime AsDateTime(this string date) => DateTime.ParseExact(date, "yyyy/MM/dd HH:mm:ss.fff", null, AssumeUniversal | AdjustToUniversal);
+
+        public static byte[] AsBytes(this string text) => System.Text.Encoding.ASCII.GetBytes(text);
     }
 }

--- a/HotFix.Test/core/field/checking_the_value_for_datetime_equality.cs
+++ b/HotFix.Test/core/field/checking_the_value_for_datetime_equality.cs
@@ -11,7 +11,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_a_valid_datetime()
         {
-            var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=XXXXXX-YY:YY:YY.ZZZ\u0001"), 0, new Segment(3, 21), 25, 0);
+            var field = new FIXField("34=XXXXXX-YY:YY:YY.ZZZ\u0001".AsBytes(), 0, new Segment(3, 21), 25, 0);
 
             field.Is("2017/03/27 09:34:21.456".AsDateTime()).Should().Be(false);
         }
@@ -19,7 +19,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_equal_to_the_input()
         {
-            var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=20170423-12:32:23.123\u0001"), 0, new Segment(3, 21), 25, 0);
+            var field = new FIXField("34=20170423-12:32:23.123\u0001".AsBytes(), 0, new Segment(3, 21), 25, 0);
 
             field.Is("2017/03/27 09:34:21.456".AsDateTime()).Should().Be(false);
         }
@@ -27,7 +27,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_true_when_the_value_is_equal_to_the_input()
         {
-            var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=20170327-09:34:21.456\u0001"), 0, new Segment(3, 21), 25, 0);
+            var field = new FIXField("34=20170327-09:34:21.456\u0001".AsBytes(), 0, new Segment(3, 21), 25, 0);
 
             field.Is("2017/03/27 09:34:21.456".AsDateTime()).Should().Be(true);
         }

--- a/HotFix.Test/core/field/checking_the_value_for_double_equality.cs
+++ b/HotFix.Test/core/field/checking_the_value_for_double_equality.cs
@@ -11,7 +11,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_a_valid_double()
         {
-            var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=XXXXXX\u0001"), 0, new Segment(3, 6), 10, 0);
+            var field = new FIXField("34=XXXXXX\u0001".AsBytes(), 0, new Segment(3, 6), 10, 0);
 
             field.Is(123.45d).Should().Be(false);
         }
@@ -19,7 +19,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_equal_to_the_input()
         {
-            var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=543.21\u0001"), 0, new Segment(3, 6), 10, 0);
+            var field = new FIXField("34=543.21\u0001".AsBytes(), 0, new Segment(3, 6), 10, 0);
 
             field.Is(123.45d).Should().Be(false);
         }
@@ -27,7 +27,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_true_when_the_value_is_equal_to_the_input()
         {
-            var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=123.45\u0001"), 0, new Segment(3, 6), 10, 0);
+            var field = new FIXField("34=123.45\u0001".AsBytes(), 0, new Segment(3, 6), 10, 0);
 
             field.Is(123.45d).Should().Be(true);
         }

--- a/HotFix.Test/core/field/checking_the_value_for_integer_equality.cs
+++ b/HotFix.Test/core/field/checking_the_value_for_integer_equality.cs
@@ -11,7 +11,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_a_valid_integer()
         {
-            var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=XXXXX\u0001"), 0, new Segment(3, 5), 9, 0);
+            var field = new FIXField("34=XXXXX\u0001".AsBytes(), 0, new Segment(3, 5), 9, 0);
 
             field.Is(12345).Should().Be(false);
         }
@@ -19,7 +19,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_equal_to_the_input()
         {
-            var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=54321\u0001"), 0, new Segment(3, 5), 9, 0);
+            var field = new FIXField("34=54321\u0001".AsBytes(), 0, new Segment(3, 5), 9, 0);
 
             field.Is(12345).Should().Be(false);
         }
@@ -27,7 +27,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_true_when_the_value_is_equal_to_the_input()
         {
-            var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=12345\u0001"), 0, new Segment(3, 5), 9, 0);
+            var field = new FIXField("34=12345\u0001".AsBytes(), 0, new Segment(3, 5), 9, 0);
 
             field.Is(12345).Should().Be(true);
         }

--- a/HotFix.Test/core/field/checking_the_value_for_long_equality.cs
+++ b/HotFix.Test/core/field/checking_the_value_for_long_equality.cs
@@ -11,7 +11,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_a_valid_long()
         {
-            var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=XXXXX\u0001"), 0, new Segment(3, 5), 9, 0);
+            var field = new FIXField("34=XXXXX\u0001".AsBytes(), 0, new Segment(3, 5), 9, 0);
 
             field.Is(12345L).Should().Be(false);
         }
@@ -19,7 +19,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_equal_to_the_input()
         {
-            var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=54321\u0001"), 0, new Segment(3, 5), 9, 0);
+            var field = new FIXField("34=54321\u0001".AsBytes(), 0, new Segment(3, 5), 9, 0);
 
             field.Is(12345L).Should().Be(false);
         }
@@ -27,7 +27,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_true_when_the_value_is_equal_to_the_input()
         {
-            var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=12345\u0001"), 0, new Segment(3, 5), 9, 0);
+            var field = new FIXField("34=12345\u0001".AsBytes(), 0, new Segment(3, 5), 9, 0);
 
             field.Is(12345L).Should().Be(true);
         }

--- a/HotFix.Test/core/field/checking_the_value_for_string_equality.cs
+++ b/HotFix.Test/core/field/checking_the_value_for_string_equality.cs
@@ -11,7 +11,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_false_when_the_value_is_not_equal_to_the_input()
         {
-            var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=XXXXXX\u0001"), 0, new Segment(3, 6), 10, 0);
+            var field = new FIXField("34=XXXXXX\u0001".AsBytes(), 0, new Segment(3, 6), 10, 0);
 
             field.Is("ABCDEF").Should().Be(false);
         }
@@ -19,7 +19,7 @@ namespace HotFix.Test.core.field
         [TestMethod]
         public void returns_true_when_the_value_is_equal_to_the_input()
         {
-            var field = new FIXField(System.Text.Encoding.ASCII.GetBytes("34=ABCDEF\u0001"), 0, new Segment(3, 6), 10, 0);
+            var field = new FIXField("34=ABCDEF\u0001".AsBytes(), 0, new Segment(3, 6), 10, 0);
 
             field.Is("ABCDEF").Should().Be(true);
         }

--- a/HotFix.Test/core/message/check_for_a_field.cs
+++ b/HotFix.Test/core/message/check_for_a_field.cs
@@ -21,7 +21,7 @@ namespace HotFix.Test.core.message
         [TestMethod]
         public void returns_true_when_the_field_exists()
         {
-            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(Logon.AsBytes(), 0, Logon.Length);
 
             Message.Contains(8).Should().Be(true);
             Message.Contains(9).Should().Be(true);

--- a/HotFix.Test/core/message/converting_to_string.cs
+++ b/HotFix.Test/core/message/converting_to_string.cs
@@ -21,7 +21,7 @@ namespace HotFix.Test.core.message
         [TestMethod]
         public void returns_the_original_string()
         {
-            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(Logon.AsBytes(), 0, Logon.Length);
 
             Message.ToString().Should().Be(Logon);
         }

--- a/HotFix.Test/core/message/parse_from_string.cs
+++ b/HotFix.Test/core/message/parse_from_string.cs
@@ -21,7 +21,7 @@ namespace HotFix.Test.core.message
         [TestMethod]
         public void succeeds_when_the_message_is_valid()
         {
-            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(Logon.AsBytes(), 0, Logon.Length);
 
             Message.Valid.Should().Be(true);
             Message.Count.Should().Be(11);
@@ -32,7 +32,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("8=FIX.4.2\u0001", "");
 
-            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(Logon.AsBytes(), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -43,7 +43,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("9=70\u0001", "");
 
-            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(Logon.AsBytes(), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -54,7 +54,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("35=A\u0001", "");
 
-            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(Logon.AsBytes(), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -65,7 +65,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("10=231\u0001", "");
 
-            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(Logon.AsBytes(), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -76,7 +76,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("34=1\u0001", "=1\u0001");
 
-            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(Logon.AsBytes(), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -87,7 +87,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("9=70\u0001", "9=81\u0001");
 
-            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(Logon.AsBytes(), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -98,7 +98,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("10=231\u0001", "10=100\u0001");
 
-            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(Logon.AsBytes(), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -109,7 +109,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("34=1\u0001", "3X=1\u0001");
 
-            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(Logon.AsBytes(), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);
@@ -120,7 +120,7 @@ namespace HotFix.Test.core.message
         {
             Logon = Logon.Replace("34=1\u0001", "34=\u0001");
 
-            Message.Parse(System.Text.Encoding.ASCII.GetBytes(Logon), 0, Logon.Length);
+            Message.Parse(Logon.AsBytes(), 0, Logon.Length);
 
             Message.Valid.Should().Be(false);
             Message.Count.Should().Be(0);

--- a/HotFix.Test/core/message/retrieve_a_field.cs
+++ b/HotFix.Test/core/message/retrieve_a_field.cs
@@ -21,7 +21,7 @@ namespace HotFix.Test.core.message
         [TestMethod]
         public void succeeds_when_the_field_exists()
         {
-            var bytes = System.Text.Encoding.ASCII.GetBytes(Logon);
+            var bytes = Logon.AsBytes();
             Message.Parse(bytes, 0, bytes.Length);
 
             Message[  8].AsString.Should().Be("FIX.4.2");

--- a/HotFix.Test/core/message/writing_to_a_byte_array.cs
+++ b/HotFix.Test/core/message/writing_to_a_byte_array.cs
@@ -13,7 +13,7 @@ namespace HotFix.Test.core.message
         {
             var message = new FIXMessage();
             var logon = "8=FIX.4.2|9=70|35=A|34=1|52=20170607-12:17:52.355|49=DAEV|56=TARGET|98=0|108=5|141=Y|10=231|".Replace("|", "\u0001");
-            var bytes = System.Text.Encoding.ASCII.GetBytes(logon);
+            var bytes = logon.AsBytes();
             var target = new byte[100];
 
             message

--- a/HotFix.Test/utilities/reading/datetimes.cs
+++ b/HotFix.Test/utilities/reading/datetimes.cs
@@ -11,7 +11,7 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void timestamp()
         {
-            var result = System.Text.Encoding.ASCII.GetBytes("20170327-15:45:13").ReadDateTime();
+            var result = "20170327-15:45:13".AsBytes().ReadDateTime();
 
             result.Should().Be("2017/03/27 15:45:13.000".AsDateTime());
         }
@@ -19,7 +19,7 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void timestamp_with_milliseconds()
         {
-            var result = System.Text.Encoding.ASCII.GetBytes("20170327-15:45:13.596").ReadDateTime();
+            var result = "20170327-15:45:13.596".AsBytes().ReadDateTime();
 
             result.Should().Be("2017/03/27 15:45:13.596".AsDateTime());
         }

--- a/HotFix.Test/utilities/reading/floats.cs
+++ b/HotFix.Test/utilities/reading/floats.cs
@@ -11,61 +11,61 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void zero()
         {
-            System.Text.Encoding.ASCII.GetBytes("0").ReadFloat().Should().Be(0d);
+            "0".AsBytes().ReadFloat().Should().Be(0d);
         }
 
         [TestMethod]
         public void zero_with_decimals()
         {
-            System.Text.Encoding.ASCII.GetBytes("0.0").ReadFloat().Should().Be(0.0d);
+            "0.0".AsBytes().ReadFloat().Should().Be(0.0d);
         }
 
         [TestMethod]
         public void positive()
         {
-            System.Text.Encoding.ASCII.GetBytes("123").ReadFloat().Should().Be(123d);
+            "123".AsBytes().ReadFloat().Should().Be(123d);
         }
 
         [TestMethod]
         public void positive_with_decimals()
         {
-            System.Text.Encoding.ASCII.GetBytes("123.456789").ReadFloat().Should().Be(123.456789d);
+            "123.456789".AsBytes().ReadFloat().Should().Be(123.456789d);
         }
 
         [TestMethod]
         public void positive_with_decimals_and_leading_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("000123.456789").ReadFloat().Should().Be(123.456789d);
+            "000123.456789".AsBytes().ReadFloat().Should().Be(123.456789d);
         }
 
         [TestMethod]
         public void positive_with_decimals_and_trailing_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("123.456789000").ReadFloat().Should().Be(123.456789d);
+            "123.456789000".AsBytes().ReadFloat().Should().Be(123.456789d);
         }
 
         [TestMethod]
         public void negative()
         {
-            System.Text.Encoding.ASCII.GetBytes("-123").ReadFloat().Should().Be(-123d);
+            "-123".AsBytes().ReadFloat().Should().Be(-123d);
         }
 
         [TestMethod]
         public void negative_with_decimals()
         {
-            System.Text.Encoding.ASCII.GetBytes("-123.456789").ReadFloat().Should().Be(-123.456789d);
+            "-123.456789".AsBytes().ReadFloat().Should().Be(-123.456789d);
         }
 
         [TestMethod]
         public void negative_with_decimals_and_leading_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("-000123.456789").ReadFloat().Should().Be(-123.456789d);
+            "-000123.456789".AsBytes().ReadFloat().Should().Be(-123.456789d);
         }
 
         [TestMethod]
         public void negative_with_decimals_and_trailing_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("-123.456789000").ReadFloat().Should().Be(-123.456789d);
+            "-123.456789000".AsBytes().ReadFloat().Should().Be(-123.456789d);
         }
     }
 }

--- a/HotFix.Test/utilities/reading/ints.cs
+++ b/HotFix.Test/utilities/reading/ints.cs
@@ -11,31 +11,31 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void zero()
         {
-            System.Text.Encoding.ASCII.GetBytes("0").ReadInt().Should().Be(0);
+            "0".AsBytes().ReadInt().Should().Be(0);
         }
 
         [TestMethod]
         public void positive()
         {
-            System.Text.Encoding.ASCII.GetBytes("123").ReadInt().Should().Be(123);
+            "123".AsBytes().ReadInt().Should().Be(123);
         }
 
         [TestMethod]
         public void positive_with_leading_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("000123").ReadInt().Should().Be(123);
+            "000123".AsBytes().ReadInt().Should().Be(123);
         }
 
         [TestMethod]
         public void negative()
         {
-            System.Text.Encoding.ASCII.GetBytes("-123").ReadInt().Should().Be(-123);
+            "-123".AsBytes().ReadInt().Should().Be(-123);
         }
 
         [TestMethod]
         public void negative_with_leading_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("-000123").ReadInt().Should().Be(-123);
+            "-000123".AsBytes().ReadInt().Should().Be(-123);
         }
     }
 }

--- a/HotFix.Test/utilities/reading/longs.cs
+++ b/HotFix.Test/utilities/reading/longs.cs
@@ -11,31 +11,31 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void zero()
         {
-            System.Text.Encoding.ASCII.GetBytes("0").ReadLong().Should().Be(0);
+            "0".AsBytes().ReadLong().Should().Be(0);
         }
 
         [TestMethod]
         public void positive()
         {
-            System.Text.Encoding.ASCII.GetBytes("1234567890987654321").ReadLong().Should().Be(1234567890987654321L);
+            "1234567890987654321".AsBytes().ReadLong().Should().Be(1234567890987654321L);
         }
 
         [TestMethod]
         public void positive_with_leading_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("0001234567890987654321").ReadLong().Should().Be(1234567890987654321L);
+            "0001234567890987654321".AsBytes().ReadLong().Should().Be(1234567890987654321L);
         }
 
         [TestMethod]
         public void negative()
         {
-            System.Text.Encoding.ASCII.GetBytes("-1234567890987654321").ReadLong().Should().Be(-1234567890987654321L);
+            "-1234567890987654321".AsBytes().ReadLong().Should().Be(-1234567890987654321L);
         }
 
         [TestMethod]
         public void negative_with_leading_zeros()
         {
-            System.Text.Encoding.ASCII.GetBytes("-0001234567890987654321").ReadLong().Should().Be(-1234567890987654321L);
+            "-0001234567890987654321".AsBytes().ReadLong().Should().Be(-1234567890987654321L);
         }
     }
 }

--- a/HotFix.Test/utilities/reading/strings.cs
+++ b/HotFix.Test/utilities/reading/strings.cs
@@ -11,19 +11,19 @@ namespace HotFix.Test.utilities.reading
         [TestMethod]
         public void empty()
         {
-            System.Text.Encoding.ASCII.GetBytes("").ReadString().Should().Be("");
+            "".AsBytes().ReadString().Should().Be("");
         }
 
         [TestMethod]
         public void small()
         {
-            System.Text.Encoding.ASCII.GetBytes("XXX").ReadString().Should().Be("XXX");
+            "XXX".AsBytes().ReadString().Should().Be("XXX");
         }
 
         [TestMethod]
         public void large()
         {
-            System.Text.Encoding.ASCII.GetBytes("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890,.;'#][/=-_+{}~@:?><").ReadString().Should().Be("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890,.;'#][/=-_+{}~@:?><");
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890,.;'#][/=-_+{}~@:?><".AsBytes().ReadString().Should().Be("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890,.;'#][/=-_+{}~@:?><");
         }
     }
 }


### PR DESCRIPTION
Introduced shorthand for `System.Text.Encoding.ASCII.GetBytes` in the test project and refactored tests to use the shorter method