### PR TITLE
Feature/error callback

### DIFF
--- a/HotFix/Core/Engine.cs
+++ b/HotFix/Core/Engine.cs
@@ -66,7 +66,7 @@ namespace HotFix.Core
         /// <param name="logout">The logout callback.</param> 
         /// <param name="inbound">The inbound message callback.</param>
         /// <param name="outbound">The outbound message callback.</param> 
-        public void Run(Configuration configuration, Action<Session> logon = null, Action<Session> logout = null, Action<Session, FIXMessage> inbound = null, Action<Session, FIXMessageWriter> outbound = null)
+        public void Run(Configuration configuration, Action<Session> logon = null, Action<Session> logout = null, Action<Session, FIXMessage> inbound = null, Action<Session, FIXMessageWriter> outbound = null, Action<Exception> error = null)
         {
             while (true)
             {
@@ -106,6 +106,8 @@ namespace HotFix.Core
                 catch (Exception e)
                 {
                     Debug.WriteLine(e);
+
+                    error?.Invoke(e);
                     
                     Thread.Sleep(10000);
                 }

--- a/HotFix/Core/Engine.cs
+++ b/HotFix/Core/Engine.cs
@@ -58,14 +58,16 @@ namespace HotFix.Core
         /// Runs a session for the provided configuration, allowing logon, logout and message handler to be specified. 
         /// <remarks> 
         /// The logon and logout callbacks are invoked after the session has successfully logged on or out. 
-        /// The message handler should return false for every message it does not handle so that the session can deal with it. 
+        /// The inbound and outbound callbacks are invoked after a message is received or sent.
+        /// The error callback is invoked when the session throws an exception - the session is then restarted.
         /// </remarks> 
         /// </summary> 
         /// <param name="configuration">The session configuration.</param> 
         /// <param name="logon">The logon callback.</param> 
         /// <param name="logout">The logout callback.</param> 
         /// <param name="inbound">The inbound message callback.</param>
-        /// <param name="outbound">The outbound message callback.</param> 
+        /// <param name="outbound">The outbound message callback.</param>
+        /// <param name="error">The error callback.</param> 
         public void Run(Configuration configuration, Action<Session> logon = null, Action<Session> logout = null, Action<Session, FIXMessage> inbound = null, Action<Session, FIXMessageWriter> outbound = null, Action<Exception> error = null)
         {
             while (true)

--- a/HotFix/Core/Engine.cs
+++ b/HotFix/Core/Engine.cs
@@ -55,19 +55,14 @@ namespace HotFix.Core
         }
 
         /// <summary> 
-        /// Runs a session for the provided configuration, allowing logon, logout and message handler to be specified. 
-        /// <remarks> 
-        /// The logon and logout callbacks are invoked after the session has successfully logged on or out. 
-        /// The inbound and outbound callbacks are invoked after a message is received or sent.
-        /// The error callback is invoked when the session throws an exception - the session is then restarted.
-        /// </remarks> 
+        /// Runs a session for the provided configuration, allowing callbacks to be specified for different events.
         /// </summary> 
         /// <param name="configuration">The session configuration.</param> 
-        /// <param name="logon">The logon callback.</param> 
-        /// <param name="logout">The logout callback.</param> 
-        /// <param name="inbound">The inbound message callback.</param>
-        /// <param name="outbound">The outbound message callback.</param>
-        /// <param name="error">The error callback.</param> 
+        /// <param name="logon">Invoked after a session has successfully logged on.</param> 
+        /// <param name="logout">Invoked after a session has successfully logged out.</param> 
+        /// <param name="inbound">Invoked after a message is received.</param>
+        /// <param name="outbound">Invoked after a message is sent.</param>
+        /// <param name="error">Invoked when the session throws an exception - the session is then restarted.</param> 
         public void Run(Configuration configuration, Action<Session> logon = null, Action<Session> logout = null, Action<Session, FIXMessage> inbound = null, Action<Session, FIXMessageWriter> outbound = null, Action<Exception> error = null)
         {
             while (true)

--- a/HotFix/Core/Engine.cs
+++ b/HotFix/Core/Engine.cs
@@ -60,9 +60,9 @@ namespace HotFix.Core
         /// <param name="configuration">The session configuration.</param> 
         /// <param name="logon">Invoked after a session has successfully logged on.</param> 
         /// <param name="logout">Invoked after a session has successfully logged out.</param> 
-        /// <param name="inbound">Invoked after a message is received.</param>
+        /// <param name="inbound">Invoked after a message is received (validated but not consumed by the session).</param>
         /// <param name="outbound">Invoked after a message is sent.</param>
-        /// <param name="error">Invoked when the session throws an exception - the session is then restarted.</param> 
+        /// <param name="error">Invoked when the session throws an exception before the session is restarted.</param> 
         public void Run(Configuration configuration, Action<Session> logon = null, Action<Session> logout = null, Action<Session, FIXMessage> inbound = null, Action<Session, FIXMessageWriter> outbound = null, Action<Exception> error = null)
         {
             while (true)
@@ -102,8 +102,6 @@ namespace HotFix.Core
                 }
                 catch (Exception e)
                 {
-                    Debug.WriteLine(e);
-
                     error?.Invoke(e);
                     
                     Thread.Sleep(10000);


### PR DESCRIPTION
Introduced error callback:
 - Optional error callback in the engine `Run` method
 - Fires when an exception is thrown while the engine is running